### PR TITLE
Refactor gender type to Gender and enhance member import

### DIFF
--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -78,6 +78,15 @@ class Member extends Model
         });
     }
 
+    public function scopeHasPointsToggle($query, $args)
+    {
+        if ($args['hasPoints'] ?? true) {
+            return $query->hasPoints();
+        }
+
+        return $query;
+    }
+
     public function scopeHasPoints(Builder $builder) : Builder
     {
         return $builder->has('points');

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
 
   artisan:
     image: flycompany/holdkamp
-    user: "1000:33"
+    user: "33:33"
     entrypoint: "php artisan"
     environment:
       TELESCOPE_ENABLED: "false"

--- a/graphql/badmintonplayer.graphql
+++ b/graphql/badmintonplayer.graphql
@@ -96,7 +96,7 @@ type ImportSquad{
 type ImportMember{
     refId: String!
     name: String!
-    gender: String!
+    gender: Gender!
     points: [ImportPoint!]
 }
 

--- a/graphql/club.graphql
+++ b/graphql/club.graphql
@@ -1,16 +1,18 @@
 extend type Query{
     membersSearch(
         name: String @where(operator: "like"),
+        refId: String @where
         excludeMembers: [Int!] @notIn(key: "id"),
         gender: [Gender!] @in,
-        orderBy: _ @orderBy(columns: ["name"])
-    ): [Member!]! @paginate(defaultCount: 10, scopes: ["hasPoints", "myClubs"]) @guard
+        orderBy: _ @orderBy(columns: ["name"]),
+        hasPoints: Boolean
+    ): [Member!]! @paginate(defaultCount: 10, scopes: ["hasPointsToggle","myClubs"]) @guard
     memberSearchCancellation(
         teamId: String!
     ): [Member!]! @paginate(defaultCount: 20, scopes: ["myClubs", "hasCancellations"]) @guard
     memberSearchPoints(
         teamId: String!
-        version: String!
+        version: Date!
         name: String @where(operator: "like")
         rankingList: MemberSearchOrderBy! = WOMEN_LEVEL
     ): [Member!]! @paginate(defaultCount: 20, builder: "FlyCompany\\Members\\MemberSearch@searchPoints", scopes: ["myClubs"]) @guard
@@ -33,27 +35,33 @@ extend type Query{
 }
 
 extend type Mutation {
-    createMember(input: CreateMemberInput! @spread): Member @create @guard @inject(context: "user.id", name: "owner_id")
+    createMember(input: CreateMemberInput! @spread): Member @upsert @guard @inject(context: "user.id", name: "owner_id")
     deleteMember(id: ID! @whereKey) : Member @delete @guard @can(ability: "delete", find: "id")
 }
 
 input CreateMemberInput {
+    id: ID
     gender: Gender!
     name: String!
     refId: String!
-    points: CreatePointMemberHasManyInput!
-    clubs: CreateMemberHasManyInput!
+    points: UpsertPointMemberInput!
+    clubs: UpsertClubsInput!
 }
 
-input CreateMemberHasManyInput {
-    connect: [ID!]
+input UpsertClubsInput {
+    upsert: [UpsertClub!]
 }
 
-input CreatePointMemberHasManyInput {
-    create: [CreatePointMemberInput!]!
+input UpsertClub {
+    id: ID
+}
+
+input UpsertPointMemberInput {
+    upsert: [CreatePointMemberInput!]!
 }
 
 input CreatePointMemberInput {
+    id: ID
     category: Category
     points: Int!
     vintage: Vintage!
@@ -101,7 +109,7 @@ type MemberWithLatestPoints {
     id: ID!
     refId: String!
     name: String!
-    gender: String!
+    gender: Gender!
     vintage: Vintage! @method(name: "getVintage")
     birthday: Date! @method(name: "getBirthday")
     latestLevelPoints: Int @rename(attribute: "latest_level_points")
@@ -123,11 +131,11 @@ type Member {
     id: ID!
     refId: String!
     name: String!
-    gender: String!
+    gender: Gender!
     ownerId: Int @rename(attribute: "owner_id")
     vintage: Vintage! @method(name: "getVintage")
     birthday: Date! @method(name: "getBirthday")
-    points(version: String @eq): [Point!] @hasMany
+    points(version: Date @eq): [Point!]! @hasMany
     clubs: [Club!]! @belongsToMany
     cancellations(teamId: String): [Cancellation!]! @hasMany(scopes: ["cancellationsByTeamId"])
 }
@@ -136,7 +144,7 @@ type Point {
     id: ID!
     points: Int
     position: Int
-    category: String
+    category: Category
     vintage: String
     version: Date
 }

--- a/graphql/teams.graphql
+++ b/graphql/teams.graphql
@@ -59,7 +59,7 @@ input UpdateCategoryInputNew {
 
 input CreateSquadMemberInput {
     category: CreateCategoryBelongsTo!
-    gender: String!
+    gender: Gender!
     name: String!
     refId: String! @rename(attribute: "member_ref_id")
     points: CreatePointHasManyInput!
@@ -176,7 +176,7 @@ type SquadMember {
     id: ID!
     refId: String! @rename(attribute: "member_ref_id")
     name: String!
-    gender: String!
+    gender: Gender!
     isInSquad: Boolean! @field(resolver: "App\\Models\\SquadMember@getIsInSquad")
     points: [SquadPoint!] @hasMany
 }

--- a/graphql/validate.graphql
+++ b/graphql/validate.graphql
@@ -35,7 +35,7 @@ input ValidateMember {
     id: ID
     refId: String!
     name: String!
-    gender: String!
+    gender: Gender!
     points: [ValidatePoint!]!
 }
 
@@ -62,7 +62,7 @@ type PlayingToHigh{
     id: ID!
     refId: String!
     category: String
-    gender: String!
+    gender: Gender!
     isYouthPlayer: Boolean!
     hasYouthPlayerPartner: Boolean!
     belowPlayer: [BelowPlayer!]

--- a/local-vendor/badmintonplayer-api/src/Models/PlayerRanking.php
+++ b/local-vendor/badmintonplayer-api/src/Models/PlayerRanking.php
@@ -49,7 +49,7 @@ class PlayerRanking
      * Level points
      * @var int|null
      */
-    public ?int $niveauPoints;
+    public ?int $niveauPoints = 0;
 
     /**
      * Club Identifier

--- a/local-vendor/badmintonplayer/src/Jobs/ImportMembers.php
+++ b/local-vendor/badmintonplayer/src/Jobs/ImportMembers.php
@@ -48,21 +48,19 @@ class ImportMembers implements ShouldQueue
             \FlyCompany\Club\Log::createLog($clubId, "Importerer medlemmer fra niveau ranglisten {$rankingList->getVersionDateCarbon()->format('Y-m-d')}", 'member-importer');
             /** @var Club $clubModel */
             $clubModel = Club::query()->where(['id' => $clubId])->firstOrFail();
+            Log::debug("Importing club-id: $clubId ($clubModel->name1)");
 
             $membersIds = [];
             /** @var PlayerRanking[] $players */
             $players = $rankingList->getPlayerRankingCollection()->getByClubId($clubId);
             foreach ($players as $player){
-                if($player->niveauPoints !== 0 && $player->niveauPoints !== null){
-                    Log::info("Upsert $player->name($player->playerNumber) with level points $player->niveauPoints ranking {$rankingList->getVersionDateCarbon()}");
-                    $member = $memberManager->addOrUpdateMember($player->playerNumber, $player->name, $player->gender);
-                    $pointsManager->addPointsByMember($member, $player->niveauPoints, 0, $rankingList->getVersionDateCarbon(), null, $player->getVintage()->value);
-                    $membersIds[] = $member->id;
-                }
+                Log::info("Upsert $player->name($player->playerNumber) from ranking {$rankingList->getVersionDateCarbon()}");
+                $member = $memberManager->addOrUpdateMember($player->playerNumber, $player->name, $player->gender);
+                $membersIds[] = $member->id;
             }
             $membersIds = array_unique($membersIds);
             $clubModel->members()->sync($membersIds);
-            \FlyCompany\Club\Log::createLog($clubId, "Medlemsimport færdig", 'member-importer');
+            \FlyCompany\Club\Log::createLog($clubId, "Medlems import færdig", 'member-importer');
             Log::info("Added ".count($membersIds)." to $clubModel->name1");
         }
         return 0;

--- a/local-vendor/badmintonplayer/src/Jobs/ImportPoints.php
+++ b/local-vendor/badmintonplayer/src/Jobs/ImportPoints.php
@@ -87,11 +87,6 @@ class ImportPoints implements ShouldQueue
                         Log::info("Updating $player->name($player->gender) mix points to {$player->mixPoints} on ranking list {$rankingList->getVersionDateCarbon()}");
                         $pointsManager->addPointsByMember($member, $player->mixPoints, 0, $rankingList->getVersionDateCarbon(), $player->getMixCategory()->value, $player->getVintage()->value);
                     }
-
-                    if($player->niveauPoints !== 0 && $player->niveauPoints !== null) {
-                        Log::info("Updating $player->name($player->gender) level points to {$player->niveauPoints} on ranking list {$rankingList->getVersionDateCarbon()}");
-                        $pointsManager->addPointsByMember($member, $player->niveauPoints, 0, $rankingList->getVersionDateCarbon(), null, $player->getVintage()->value);
-                    }
                 }
             }
         });

--- a/local-vendor/members/src/MemberSearch.php
+++ b/local-vendor/members/src/MemberSearch.php
@@ -8,6 +8,7 @@ use App\Models\Member;
 use GraphQL\Type\Definition\ResolveInfo;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class MemberSearch
@@ -39,7 +40,7 @@ class MemberSearch
         return $builder;
     }
 
-    private function applyRankingList(Builder $builder, string $rankingList, string $version)
+    private function applyRankingList(Builder $builder, string $rankingList, Carbon $version)
     {
         if ($rankingList === 'ALL_LEVEL') {
             $builder->whereNull('points.category')

--- a/resources/js/admin-v2/helpers.js
+++ b/resources/js/admin-v2/helpers.js
@@ -53,10 +53,10 @@ export function isYoungPlayer(player, category) {
             return false;
         } else {
             if (category === 'MD') {
-                if (player.gender === 'M' && point.category === 'MxH') {
+                if (player.gender === 'MEN' && point.category === 'MxH') {
                     return point.vintage.toUpperCase() === 'U17' || point.vintage.toUpperCase() === 'U19'
                 }
-                if (player.gender === 'K' && point.category === 'MxD') {
+                if (player.gender === 'WOMEN' && point.category === 'MxD') {
                     return point.vintage.toUpperCase() === 'U17' || point.vintage.toUpperCase() === 'U19'
                 }
             }
@@ -115,10 +115,10 @@ export function findLevel(member, category) {
     }
     for (let point of member.points) {
         if (category === 'MD') {
-            if (member.gender === 'M' && point.category === 'MxH') {
+            if (member.gender === 'MEN' && point.category === 'MxH') {
                 return point.points
             }
-            if (member.gender === 'K' && point.category === 'MxD') {
+            if (member.gender === 'WOMEN' && point.category === 'MxD') {
                 return point.points
             }
         }
@@ -147,10 +147,10 @@ export function findPositions(member, show = 'all') {
         if (point.category === 'DD' && (show === 'all' || show === 'DD')) {
             summary.push('DD:' + point.points)
         }
-        if (point.category === 'MxH' && member.gender === 'M' && (show === 'all' || show === 'MD')) {
+        if (point.category === 'MxH' && member.gender === 'MEN' && (show === 'all' || show === 'MD')) {
             summary.push('MxH:' + point.points)
         }
-        if (point.category === 'MxD' && member.gender === 'K' && (show === 'all' || show === 'MD')) {
+        if (point.category === 'MxD' && member.gender === 'WOMEN' && (show === 'all' || show === 'MD')) {
             summary.push('MxD:' + point.points)
         }
     }
@@ -281,13 +281,13 @@ export function isWomensSingle(category) {
 
 export function containsWomen(category) {
     return category.players.some((player) => {
-        return player.gender === 'K';
+        return player.gender === 'WOMEN';
     });
 }
 
 export function containsMen(category) {
     return category.players.some((player) => {
-        return player.gender === 'M';
+        return player.gender === 'MEN';
     });
 }
 

--- a/resources/js/admin-v2/views/common/PlayerSearch.vue
+++ b/resources/js/admin-v2/views/common/PlayerSearch.vue
@@ -126,7 +126,7 @@ export default {
             }
         },
         membersSearch: {
-            query: gql`query membersSearch($name: String, $excludeMembers: [Int!], $version: String, $gender: [Gender!]){
+            query: gql`query membersSearch($name: String, $excludeMembers: [Int!], $version: Date, $gender: [Gender!]){
                       membersSearch(name: $name, excludeMembers: $excludeMembers, orderBy: { column: NAME, order: ASC }, gender: $gender) {
                         data {
                           id
@@ -157,7 +157,7 @@ export default {
                 if(this?.squad?.version){
                     params.version = this?.squad?.version
                 }else if(!!this.version){
-                    params.version = this.version.getFullYear() + "-" + (this.version.getMonth() + 1) + "-" + this.version.getDate()
+                    params.version = this.version.toISOString().slice(0, 10)
                 }
                 return params
             },

--- a/resources/js/admin-v2/views/team-fight/AddMemberModal.vue
+++ b/resources/js/admin-v2/views/team-fight/AddMemberModal.vue
@@ -173,7 +173,6 @@ export default {
                     @click="$emit('close')"/>
             </header>
             <section class="modal-card-body">
-                {{this.points}}
                 <p>Spilleren bliver oprettet på ranglisten <strong>{{ versionMonth }}</strong>, spilleren kan ses af <strong>alle</strong> som har klubben tilknyttet.</p>
                 <hr/>
                 <b-field grouped label="Badmintonplayer ID">

--- a/resources/js/admin-v2/views/team-fight/AddMemberModal.vue
+++ b/resources/js/admin-v2/views/team-fight/AddMemberModal.vue
@@ -17,43 +17,116 @@ export default {
             vintage: 'SEN',
             club: null,
             points: [
-                {category: "LEVEL", label: "Niveau", points: 1000},
-                {category: "SINGLE", label: "Single", points: 1000},
-                {category: "DOUBLE", label: "Double", points: 1000},
-                {category: "MIXDOUBLE", label: "Mix double", points: 1000}
+                {id: null, category: "SINGLE", label: "Single", points: 1000},
+                {id: null, category: "DOUBLE", label: "Double", points: 1000},
+                {id: null, category: "MIXDOUBLE", label: "Mix double", points: 1000}
             ],
             loading: false
         }
     },
     computed: {
         vintageOptions: vintageOptions,
+        memberExists(){
+            return this.membersSearch?.data?.length > 0;
+        },
+        refId(){
+            return this.refBirthday + '-' + this.refEndId
+        },
+        versionMonth(){
+            return timeToMonth(this.version.toISOString().substring(0, 10))
+        }
     },
     apollo: {
         me: {
             query: ME
+        },
+        membersSearch: {
+            query: gql`query membersSearch($refId: String, $version: Date){
+                      membersSearch(refId: $refId) {
+                        data {
+                          id
+                          gender
+                          name
+                          refId
+                          points(version: $version){
+                            id
+                            points
+                            position
+                            category
+                            version
+                            vintage
+                          }
+                          clubs{
+                            id
+                            name1
+                            initialized
+                          }
+                        }
+                      }
+                    }
+                `,
+            variables() {
+                return {
+                    refId: this.refId,
+                    version: this.version.toISOString().slice(0, 10)
+                }
+            },
+            result({data}){
+                if(data.membersSearch.data.length > 0){
+                    let member = data.membersSearch.data[0]
+                    this.gender = member.gender
+                    this.name = member.name
+                    this.club = member.clubs[0].id
+                    this.points.forEach(point => {
+                        let remotePoints = data.membersSearch.data[0].points.find(pointItem => pointItem.category === convertCategoryAndGenderToFinalCategory(point.category, this.gender));
+                        if(remotePoints !== undefined){
+                            point.id = remotePoints.id
+                            point.points = remotePoints.points;
+                        }
+                    });
+                }
+                console.log(data)
+            },
+            fetchPolicy: "network-only"
         }
     },
     methods: {
-        timeToMonth,
         createMember(e) {
             this.loading = true
+            let memberId = null
+            if(this.membersSearch?.data?.length > 0){
+                memberId = this.membersSearch.data[0].id
+            }
             this.$apollo
                 .mutate({
                             mutation: gql`
-                                mutation createMember($input: CreateMemberInput!){
+                                mutation createMember($input: CreateMemberInput!, $version: Date){
                                     createMember(input: $input){
                                         id
                                         gender
+                                        name
+                                          refId
+                                          points(version: $version){
+                                            id
+                                            points
+                                            position
+                                            category
+                                            version
+                                            vintage
+                                          }
                                     }
                                 }
                             `,
                             variables: {
+                                version: this.version.toISOString().substring(0,10),
                                 input: {
+                                    id: memberId,
                                     gender: this.gender,
                                     name: this.name,
-                                    refId: this.refBirthday + '-' + this.refEndId,
+                                    refId: this.refId,
                                     points: {
-                                        create: this.points.map((point) => ({
+                                        upsert: this.points.map((point) => ({
+                                            id: point.id,
                                             category: convertCategoryAndGenderToFinalCategory(point.category, this.gender),
                                             points: point.points,
                                             vintage: this.vintage,
@@ -61,7 +134,7 @@ export default {
                                         }))
                                     },
                                     clubs: {
-                                        connect: [this.club]
+                                        upsert: [{id: this.club}]
                                     }
                                 }
                             }
@@ -100,17 +173,9 @@ export default {
                     @click="$emit('close')"/>
             </header>
             <section class="modal-card-body">
-                <b-message type="is-info">Brug kun denne funktion hvis spilleren ikke findes på nembadminton.dk men på badmintonplayer.dk.</b-message>
-                <p>Spilleren bliver oprettet på ranglisten <strong>{{ timeToMonth(this.version.toISOString().substring(0, 10)) }}</strong>, spilleren kan ses af <strong>alle</strong> som har klubben tilknyttet.</p>
+                {{this.points}}
+                <p>Spilleren bliver oprettet på ranglisten <strong>{{ versionMonth }}</strong>, spilleren kan ses af <strong>alle</strong> som har klubben tilknyttet.</p>
                 <hr/>
-                <b-field label="Navn">
-                    <b-input
-                        type="text"
-                        v-model="name"
-                        placeholder="Name"
-                        required>
-                    </b-input>
-                </b-field>
                 <b-field grouped label="Badmintonplayer ID">
                     <b-field expanded>
                         <b-field>
@@ -118,6 +183,15 @@ export default {
                             <b-input v-model="refEndId" type="text" minlength="2" maxlength="2" placeholder="XX" required></b-input>
                         </b-field>
                     </b-field>
+                </b-field>
+                <b-message v-if="memberExists" type="is-info">Brugeren med {{this.refId}} findes allerede i systemet. Der vil ikke blive oprettet en ny bruger, men i stedet vil brugerens point blive opdateret på {{versionMonth}} til de nye data.</b-message>
+                <b-field label="Navn">
+                    <b-input
+                        type="text"
+                        v-model="name"
+                        placeholder="Name"
+                        required>
+                    </b-input>
                 </b-field>
                 <b-field label="Køn">
                     <b-select v-model="gender" required expanded>
@@ -132,13 +206,13 @@ export default {
                 </b-field>
                 <b-field label="Klub">
                     <b-select v-model="club" expanded required>
-                        <option v-for="club in this.me?.clubs" :key="club.id" :value="club.id">{{ club.name1 }}</option>
+                        <option v-for="club in me?.clubs" :key="club.id" :value="club.id">{{ club.name1 }}</option>
                     </b-select>
                 </b-field>
                 <hr/>
                 <label class="label">Points</label>
                 <b-field horizontal :label="point.label" v-for="point in this.points" :key="point.category">
-                    <b-input type="number" v-model="point.points" required></b-input>
+                    <b-input type="number" v-model.number="point.points" required></b-input>
                 </b-field>
             </section>
             <footer class="modal-card-foot">

--- a/resources/js/admin-v2/views/team-fight/EditPlayerModal.vue
+++ b/resources/js/admin-v2/views/team-fight/EditPlayerModal.vue
@@ -5,7 +5,7 @@ import {debounce} from "../../helpers";
 
 export default {
     name: "EditPlayerModal",
-    props: ['value'],
+    props: ['player'],
     data() {
         return {
             loading: false
@@ -54,20 +54,20 @@ export default {
     <form action="">
         <div class="modal-card" style="width: auto">
             <header class="modal-card-head">
-                <p class="modal-card-title">Rediger <strong>{{ value.name }}</strong> points</p>
+                <p class="modal-card-title">Rediger <strong>{{ player.name }}</strong> points</p>
                 <button
                     type="button"
                     class="delete"
                     @click="$emit('close')"/>
             </header>
             <section class="modal-card-body">
-                <p>Ændringerne er kun lokale, så pointene ændres kun for denne spiller i denne kategori. Husk at opdatere pointene for samme spiller i anden kategori. En manuelt redigeret spiller er markeret med <b-icon type="is-info" icon="information" /></p>
+                <b-message type="is-warning">Ændringerne er kun lokale, så pointene ændres kun for denne spiller i denne kategori. Husk at opdatere pointene for samme spiller i anden kategori. En manuelt redigeret spiller er markeret med <b-icon type="is-info" icon="information" /></b-message>
                 <hr/>
-                <b-field v-for="points in value.points" :key="points.id" :label="resolveCategoryName(points.category)">
+                <b-field v-for="innerPoints in player.points" :key="innerPoints.id" :label="resolveCategoryName(innerPoints.category)">
                     <b-input
                         type="number"
-                        @input="updatePoint(points, $event)"
-                        v-model="points.points"
+                        @input="updatePoint(innerPoints, $event)"
+                        :value="innerPoints.points"
                         required>
                     </b-input>
                 </b-field>

--- a/resources/js/admin-v2/views/team-fight/PlayersListSearch.vue
+++ b/resources/js/admin-v2/views/team-fight/PlayersListSearch.vue
@@ -327,7 +327,7 @@ export default {
         if (this.hideCancellation) {
           return gql`
                         query memberSearchPoints(
-                            $version: String!,
+                            $version: Date!,
                             $page: Int,
                             $first: Int,
                             $name: String,
@@ -363,7 +363,7 @@ export default {
                     `
         } else {
           return gql`
-                        query memberSearchCancellation($teamId: String!, $version: String){
+                        query memberSearchCancellation($teamId: String!, $version: Date){
                             memberSearchCancellation(teamId: $teamId){
                                 data {
                                   id
@@ -407,7 +407,7 @@ export default {
           params.rankingList = this.rankingList
         }
         if (!!this.version) {
-          params.version = this.version.getFullYear() + "-" + (this.version.getMonth() + 1) + "-" + this.version.getDate()
+          params.version = this.version.toISOString().slice(0, 10)
         }
         if (!this.hideCancellation) {
           params.rankingList = 'ALL_LEVEL';

--- a/resources/js/admin-v2/views/team-fight/TeamFight.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamFight.vue
@@ -667,12 +667,12 @@ export default {
             outside:
                 for (const [index, squad] of this.team.squads.entries()) {
                     for (const category of squad.categories) {
-                        if (isWomenDouble(category) && category.players.length < 2 && player.gender === 'K') {
+                        if (isWomenDouble(category) && category.players.length < 2 && player.gender === 'WOMEN') {
                             this.addedPlayerNotification(index, category.name)
                             addPlayerPromise = this.addPlayerToCategory(squad, category, player)
                             foundPlace = true;
                             break outside;
-                        } else if (isMensDouble(category) && category.players.length < 2 && player.gender === 'M') {
+                        } else if (isMensDouble(category) && category.players.length < 2 && player.gender === 'MEN') {
                             this.addedPlayerNotification(index, category.name)
                             addPlayerPromise = this.addPlayerToCategory(squad, category, player)
                             foundPlace = true;
@@ -683,23 +683,23 @@ export default {
                                 addPlayerPromise = this.addPlayerToCategory(squad, category, player)
                                 foundPlace = true;
                                 break outside;
-                            } else if (containsWomen(category) && player.gender === 'M') {
+                            } else if (containsWomen(category) && player.gender === 'MEN') {
                                 this.addedPlayerNotification(index, category.name)
                                 addPlayerPromise = this.addPlayerToCategory(squad, category, player)
                                 foundPlace = true;
                                 break outside;
-                            } else if (containsMen(category) && player.gender === 'K') {
+                            } else if (containsMen(category) && player.gender === 'WOMEN') {
                                 this.addedPlayerNotification(index, category.name)
                                 addPlayerPromise = this.addPlayerToCategory(squad, category, player)
                                 foundPlace = true;
                                 break outside;
                             }
-                        } else if (isMensSingle(category) && category.players.length < 1 && player.gender === 'M') {
+                        } else if (isMensSingle(category) && category.players.length < 1 && player.gender === 'MEN') {
                             this.addedPlayerNotification(index, category.name)
                             addPlayerPromise = this.addPlayerToCategory(squad, category, player)
                             foundPlace = true;
                             break outside;
-                        } else if (isWomensSingle(category) && category.players.length < 1 && player.gender === 'K') {
+                        } else if (isWomensSingle(category) && category.players.length < 1 && player.gender === 'WOMEN') {
                             this.addedPlayerNotification(index, category.name)
                             addPlayerPromise = this.addPlayerToCategory(squad, category, player)
                             foundPlace = true;
@@ -707,6 +707,7 @@ export default {
                         }
                     }
                 }
+                console.log(player)
             if (foundPlace === false) {
                 this.$buefy.snackbar.open(
                     {

--- a/resources/js/admin-v2/views/team-fight/TeamFight.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamFight.vue
@@ -42,12 +42,6 @@
                         {{ignoreIncompleteTeam ? 'Aktiver' : 'Deaktiver'}} "Fuldendt hold" check
                     </b-tooltip>
                 </b-dropdown-item>
-                <b-dropdown-item aria-role="listitem" @click="updateToRankingList">
-                    <b-tooltip type="is-info" label="Opdater spillernes point med den valgte rangliste.">
-                        <b-icon icon="update"></b-icon>
-                        Opdater spiller point
-                    </b-tooltip>
-                </b-dropdown-item>
                 <b-dropdown-item aria-role="listitem" @click="copyTeamFight">
                     <b-icon icon="content-copy"></b-icon>
                     Kopier hele holdet

--- a/resources/js/admin-v2/views/team-fight/TeamFightPublic.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamFightPublic.vue
@@ -32,12 +32,12 @@
 
                                 <p class="fa-pull-left">
                                     <b-icon
-                                        v-show="player.gender === 'M'"
+                                        v-show="player.gender === 'MEN'"
                                         icon="mars"
                                         size="is-small">
                                     </b-icon>
                                     <b-icon
-                                        v-show="player.gender === 'K'"
+                                        v-show="player.gender === 'WOMEN'"
                                         icon="venus"
                                         size="is-small">
                                     </b-icon>

--- a/resources/js/admin-v2/views/team-fight/TeamTable.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamTable.vue
@@ -54,12 +54,12 @@
                                 </template>
                                 <p class="fa-pull-left handle" v-bind:class="highlight(player, category.category)">
                                     <b-icon
-                                        v-show="player.gender === 'M'"
+                                        v-show="player.gender === 'MEN'"
                                         icon="gender-male"
                                         size="is-small">
                                     </b-icon>
                                     <b-icon
-                                        v-show="player.gender === 'K'"
+                                        v-show="player.gender === 'WOMEN'"
                                         icon="gender-female"
                                         size="is-small">
                                     </b-icon>
@@ -125,7 +125,6 @@ import {
     isYoungPlayer, parseDate,
     resolveToolTip
 } from "../../helpers";
-import PlayersListSearch from "./PlayersListSearch.vue";
 import PlayerSearch from "../common/PlayerSearch.vue";
 import EditPlayerModal from "./EditPlayerModal.vue";
 import EditSquadModal from "./EditSquadModal.vue";
@@ -133,7 +132,7 @@ import {timeToMonth} from "./helper";
 
 export default {
     name: 'TeamTable',
-    components: {PlayerSearch, PlayersListSearch, Draggable},
+    components: {PlayerSearch, Draggable},
     props: {
         version: Date,
         clubId: String,
@@ -232,7 +231,7 @@ export default {
                 {
                     parent: this,
                     props: {
-                        value: player
+                        player: player
                     },
                     events: {
                         close() {

--- a/tests/CategoryFactory.php
+++ b/tests/CategoryFactory.php
@@ -12,12 +12,12 @@ class CategoryFactory
 
     public static function makeWomen(string $category1PointName, int $category1Points, string $category2PointName, int $category2Points, int $levelPoints, string $refId): Player
     {
-        return static::makePlayerWithPoint($category1PointName, $category2PointName, 'K', $refId, $category1Points, $category2Points, $levelPoints);
+        return static::makePlayerWithPoint($category1PointName, $category2PointName, 'WOMEN', $refId, $category1Points, $category2Points, $levelPoints);
     }
 
     public static function makeMen(string $category1PointName, int $category1Points, string $category2PointName, int $category2Points, int $levelPoints, string $refId): Player
     {
-        return static::makePlayerWithPoint($category1PointName, $category2PointName, 'M', $refId, $category1Points, $category2Points, $levelPoints);
+        return static::makePlayerWithPoint($category1PointName, $category2PointName, 'MEN', $refId, $category1Points, $category2Points, $levelPoints);
     }
 
     public static function makePlayerWithPoint(string $category1PointName, string $category2PointName, string $gender, string $refId, int $category1Points = 0, int $category2Points = 0, int $levelPoints = 0): Player

--- a/tests/GraphQL/CrossSquadsUseCases/usecase1.php
+++ b/tests/GraphQL/CrossSquadsUseCases/usecase1.php
@@ -23,7 +23,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '821',
                                                             'name' => 'Mathilde Lund',
                                                             'refId' => '970325-01',
@@ -61,7 +61,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '822',
                                                             'name' => 'Søren Frandsen',
                                                             'refId' => '840901-01',
@@ -107,7 +107,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '840',
                                                             'name' => 'Astrid Krog Sørensen',
                                                             'refId' => '951108-04',
@@ -145,7 +145,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '824',
                                                             'name' => 'Philip Madsen',
                                                             'refId' => '980315-01',
@@ -191,7 +191,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '825',
                                                             'name' => 'Louise Holst',
                                                             'refId' => '930824-05',
@@ -237,7 +237,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '826',
                                                             'name' => 'Stinne B. Enevoldsen',
                                                             'refId' => '941101-03',
@@ -283,7 +283,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '827',
                                                             'name' => 'Martin Lindved',
                                                             'refId' => '911006-03',
@@ -329,7 +329,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '828',
                                                             'name' => 'Alexander Illum',
                                                             'refId' => '920326-18',
@@ -375,7 +375,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '829',
                                                             'name' => 'Stinne B. Enevoldsen',
                                                             'refId' => '941101-03',
@@ -413,7 +413,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '830',
                                                             'name' => 'Louise Holst',
                                                             'refId' => '930824-05',
@@ -459,7 +459,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '831',
                                                             'name' => 'Philip Madsen',
                                                             'refId' => '980315-01',
@@ -497,7 +497,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '832',
                                                             'name' => 'Søren Frandsen',
                                                             'refId' => '840901-01',
@@ -543,7 +543,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '833',
                                                             'name' => 'Alexander Illum',
                                                             'refId' => '920326-18',
@@ -581,7 +581,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '834',
                                                             'name' => 'Martin Lindved',
                                                             'refId' => '911006-03',
@@ -640,7 +640,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '835',
                                                             'name' => 'Maibritt Meldgaard',
                                                             'refId' => '981105-05',
@@ -678,7 +678,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '836',
                                                             'name' => 'Bastian Brænder',
                                                             'refId' => '921110-16',
@@ -724,7 +724,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '837',
                                                             'name' => 'Caroline Bohm Veng',
                                                             'refId' => '000128-10',
@@ -762,7 +762,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '838',
                                                             'name' => 'Stephan Hjelmdal Nielsen',
                                                             'refId' => '830421-01',
@@ -808,7 +808,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '839',
                                                             'name' => 'Louise Bolding Lund',
                                                             'refId' => '990618-10',
@@ -854,7 +854,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '823',
                                                             'name' => 'Anna Schøn',
                                                             'refId' => '900216-01',
@@ -900,7 +900,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '841',
                                                             'name' => 'Victor Tang Merit',
                                                             'refId' => '950326-02',
@@ -946,7 +946,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '842',
                                                             'name' => 'Casper Brix Bruun',
                                                             'refId' => '900704-11',
@@ -992,7 +992,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '843',
                                                             'name' => 'Anders Vestergaard',
                                                             'refId' => '900427-08',
@@ -1038,7 +1038,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '844',
                                                             'name' => 'Peter Philipsen',
                                                             'refId' => '960606-06',
@@ -1077,7 +1077,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '845',
                                                             'name' => 'Maibritt Meldgaard',
                                                             'refId' => '981105-05',
@@ -1115,7 +1115,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '823',
                                                             'name' => 'Anna Schøn',
                                                             'refId' => '900216-01',
@@ -1161,7 +1161,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '846',
                                                             'name' => 'Caroline Bohm Veng',
                                                             'refId' => '000128-10',
@@ -1199,7 +1199,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'id' => '847',
                                                             'name' => 'Louise Bolding Lund',
                                                             'refId' => '990618-10',
@@ -1245,7 +1245,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '849',
                                                             'name' => 'Bastian Brænder',
                                                             'refId' => '921110-16',
@@ -1283,7 +1283,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '850',
                                                             'name' => 'Stephan Hjelmdal Nielsen',
                                                             'refId' => '830421-01',
@@ -1329,7 +1329,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '851',
                                                             'name' => 'Casper Brix Bruun',
                                                             'refId' => '900704-11',
@@ -1367,7 +1367,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '852',
                                                             'name' => 'Victor Tang Merit',
                                                             'refId' => '950326-02',
@@ -1413,7 +1413,7 @@ return [
                                                 [
                                                     0 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '853',
                                                             'name' => 'Anders Vestergaard',
                                                             'refId' => '900427-08',
@@ -1451,7 +1451,7 @@ return [
                                                         ],
                                                     1 =>
                                                         [
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'id' => '854',
                                                             'name' => 'Peter Philipsen',
                                                             'refId' => '960606-06',

--- a/tests/GraphQL/CrossSquadsUseCases/usecase2.php
+++ b/tests/GraphQL/CrossSquadsUseCases/usecase2.php
@@ -24,7 +24,7 @@ return [
                                                         [
                                                             'refId' => '010519-03',
                                                             'name' => 'Anna Do',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -65,7 +65,7 @@ return [
                                                         [
                                                             'refId' => '010613-02',
                                                             'name' => 'Magnus Gregersen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -114,7 +114,7 @@ return [
                                                         [
                                                             'refId' => '050128-01',
                                                             'name' => 'Sarah Skriver',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -155,7 +155,7 @@ return [
                                                         [
                                                             'refId' => '920421-01',
                                                             'name' => 'Frederik Houlberg',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -204,7 +204,7 @@ return [
                                                         [
                                                             'refId' => '020424-06',
                                                             'name' => 'Sofie Løth Topp',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -253,7 +253,7 @@ return [
                                                         [
                                                             'refId' => '050128-01',
                                                             'name' => 'Sarah Skriver',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -302,7 +302,7 @@ return [
                                                         [
                                                             'refId' => '001018-03',
                                                             'name' => 'Mads Sørensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -351,7 +351,7 @@ return [
                                                         [
                                                             'refId' => '990714-01',
                                                             'name' => 'Kasper Rossen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -400,7 +400,7 @@ return [
                                                         [
                                                             'refId' => '010519-03',
                                                             'name' => 'Anna Do',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -441,7 +441,7 @@ return [
                                                         [
                                                             'refId' => '020424-06',
                                                             'name' => 'Sofie Løth Topp',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -490,7 +490,7 @@ return [
                                                         [
                                                             'refId' => '010613-02',
                                                             'name' => 'Magnus Gregersen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -531,7 +531,7 @@ return [
                                                         [
                                                             'refId' => '920421-01',
                                                             'name' => 'Frederik Houlberg',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -580,7 +580,7 @@ return [
                                                         [
                                                             'refId' => '001018-03',
                                                             'name' => 'Mads Sørensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -621,7 +621,7 @@ return [
                                                         [
                                                             'refId' => '990714-01',
                                                             'name' => 'Kasper Rossen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -682,7 +682,7 @@ return [
                                                         [
                                                             'refId' => '930119-01',
                                                             'name' => 'Pernille Bundgaard',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -723,7 +723,7 @@ return [
                                                         [
                                                             'refId' => '840719-01',
                                                             'name' => 'Jacob Tovgaard',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -772,7 +772,7 @@ return [
                                                         [
                                                             'refId' => '931214-07',
                                                             'name' => 'Amalie Vestmar',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -813,7 +813,7 @@ return [
                                                         [
                                                             'refId' => '000317-02',
                                                             'name' => 'Victor Bendsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -862,7 +862,7 @@ return [
                                                         [
                                                             'refId' => '970602-05',
                                                             'name' => 'Sofie Zacho Vestergård',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -911,7 +911,7 @@ return [
                                                         [
                                                             'refId' => '940501-03',
                                                             'name' => 'Astrid Gjettermann',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -960,7 +960,7 @@ return [
                                                         [
                                                             'refId' => '990328-04',
                                                             'name' => 'Johan Simoni Haunsø',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1009,7 +1009,7 @@ return [
                                                         [
                                                             'refId' => '030611-01',
                                                             'name' => 'Malte Friis',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1058,7 +1058,7 @@ return [
                                                         [
                                                             'refId' => '910803-06',
                                                             'name' => 'Martin Thy Bjerre',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1107,7 +1107,7 @@ return [
                                                         [
                                                             'refId' => '921118-05',
                                                             'name' => 'Rasmus Skjølstrup',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1156,7 +1156,7 @@ return [
                                                         [
                                                             'refId' => '931214-07',
                                                             'name' => 'Amalie Vestmar',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1197,7 +1197,7 @@ return [
                                                         [
                                                             'refId' => '970602-05',
                                                             'name' => 'Sofie Zacho Vestergård',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1246,7 +1246,7 @@ return [
                                                         [
                                                             'refId' => '940501-03',
                                                             'name' => 'Astrid Gjettermann',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1287,7 +1287,7 @@ return [
                                                         [
                                                             'refId' => '930119-01',
                                                             'name' => 'Pernille Bundgaard',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1336,7 +1336,7 @@ return [
                                                         [
                                                             'refId' => '910803-06',
                                                             'name' => 'Martin Thy Bjerre',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1377,7 +1377,7 @@ return [
                                                         [
                                                             'refId' => '921118-05',
                                                             'name' => 'Rasmus Skjølstrup',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1426,7 +1426,7 @@ return [
                                                         [
                                                             'refId' => '000317-02',
                                                             'name' => 'Victor Bendsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1467,7 +1467,7 @@ return [
                                                         [
                                                             'refId' => '840719-01',
                                                             'name' => 'Jacob Tovgaard',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1516,7 +1516,7 @@ return [
                                                         [
                                                             'refId' => '030611-01',
                                                             'name' => 'Malte Friis',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1557,7 +1557,7 @@ return [
                                                         [
                                                             'refId' => '990328-04',
                                                             'name' => 'Johan Simoni Haunsø',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1618,7 +1618,7 @@ return [
                                                         [
                                                             'refId' => '000727-03',
                                                             'name' => 'Christinna Andersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1659,7 +1659,7 @@ return [
                                                         [
                                                             'refId' => '720113-01',
                                                             'name' => 'Lars Zilmer Jakobsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1708,7 +1708,7 @@ return [
                                                         [
                                                             'refId' => '000706-07',
                                                             'name' => 'Rikke Andersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1749,7 +1749,7 @@ return [
                                                         [
                                                             'refId' => '050122-01',
                                                             'name' => 'Thais Uggerly',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1798,7 +1798,7 @@ return [
                                                         [
                                                             'refId' => '001223-01',
                                                             'name' => 'Elisabeth Tran',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1847,7 +1847,7 @@ return [
                                                         [
                                                             'refId' => '990519-21',
                                                             'name' => 'Frederikke Enevoldsen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1896,7 +1896,7 @@ return [
                                                         [
                                                             'refId' => '020326-06',
                                                             'name' => 'Andreas Lund',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1945,7 +1945,7 @@ return [
                                                         [
                                                             'refId' => '940902-04',
                                                             'name' => 'Thorkild Bendsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1994,7 +1994,7 @@ return [
                                                         [
                                                             'refId' => '941218-02',
                                                             'name' => 'Mads Møller Christensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2043,7 +2043,7 @@ return [
                                                         [
                                                             'refId' => '970919-04',
                                                             'name' => 'Kristian Eskildsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2092,7 +2092,7 @@ return [
                                                         [
                                                             'refId' => '000727-03',
                                                             'name' => 'Christinna Andersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2133,7 +2133,7 @@ return [
                                                         [
                                                             'refId' => '001223-01',
                                                             'name' => 'Elisabeth Tran',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2182,7 +2182,7 @@ return [
                                                         [
                                                             'refId' => '000706-07',
                                                             'name' => 'Rikke Andersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2223,7 +2223,7 @@ return [
                                                         [
                                                             'refId' => '990519-21',
                                                             'name' => 'Frederikke Enevoldsen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2272,7 +2272,7 @@ return [
                                                         [
                                                             'refId' => '941218-02',
                                                             'name' => 'Mads Møller Christensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2313,7 +2313,7 @@ return [
                                                         [
                                                             'refId' => '940902-04',
                                                             'name' => 'Thorkild Bendsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2362,7 +2362,7 @@ return [
                                                         [
                                                             'refId' => '020326-06',
                                                             'name' => 'Andreas Lund',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2403,7 +2403,7 @@ return [
                                                         [
                                                             'refId' => '720113-01',
                                                             'name' => 'Lars Zilmer Jakobsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2452,7 +2452,7 @@ return [
                                                         [
                                                             'refId' => '970919-04',
                                                             'name' => 'Kristian Eskildsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2493,7 +2493,7 @@ return [
                                                         [
                                                             'refId' => '050122-01',
                                                             'name' => 'Thais Uggerly',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>

--- a/tests/GraphQL/CrossSquadsUseCases/usecase3.php
+++ b/tests/GraphQL/CrossSquadsUseCases/usecase3.php
@@ -26,7 +26,7 @@ return [
                                                         [
                                                             'refId' => '980823-03',
                                                             'name' => 'Lisa Kramer',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -59,7 +59,7 @@ return [
                                                         [
                                                             'refId' => '980920-02',
                                                             'name' => 'Rasmus Kæseler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -108,7 +108,7 @@ return [
                                                         [
                                                             'refId' => '031227-01',
                                                             'name' => 'Vibse Jonassen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -149,7 +149,7 @@ return [
                                                         [
                                                             'refId' => '930813-29',
                                                             'name' => 'Wong Fai Yin (Udl.)',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -198,7 +198,7 @@ return [
                                                         [
                                                             'refId' => '021103-01',
                                                             'name' => 'Laura Fløj Thomsen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -247,7 +247,7 @@ return [
                                                         [
                                                             'refId' => '960830-22',
                                                             'name' => 'Sabrina Solis (udl.)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -296,7 +296,7 @@ return [
                                                         [
                                                             'refId' => '940720-01',
                                                             'name' => 'Mads Emil Kristensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -345,7 +345,7 @@ return [
                                                         [
                                                             'refId' => '020325-02',
                                                             'name' => 'Mathias Solgaard',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -394,7 +394,7 @@ return [
                                                         [
                                                             'refId' => '031227-01',
                                                             'name' => 'Vibse Jonassen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -435,7 +435,7 @@ return [
                                                         [
                                                             'refId' => '980823-03',
                                                             'name' => 'Lisa Kramer',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -476,7 +476,7 @@ return [
                                                         [
                                                             'refId' => '020206-01',
                                                             'name' => 'Benjamin Illum Klindt',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -517,7 +517,7 @@ return [
                                                         [
                                                             'refId' => '930813-29',
                                                             'name' => 'Wong Fai Yin (Udl.)',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -566,7 +566,7 @@ return [
                                                         [
                                                             'refId' => '980920-02',
                                                             'name' => 'Rasmus Kæseler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -607,7 +607,7 @@ return [
                                                         [
                                                             'refId' => '940720-01',
                                                             'name' => 'Mads Emil Kristensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -668,7 +668,7 @@ return [
                                                         [
                                                             'refId' => '970512-21',
                                                             'name' => 'Arna Karen Jóhannsdóttir (EU)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -709,7 +709,7 @@ return [
                                                         [
                                                             'refId' => '011030-01',
                                                             'name' => 'Lasse Ejstrup Brunse',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -758,7 +758,7 @@ return [
                                                         [
                                                             'refId' => '040201-01',
                                                             'name' => 'Filippa Ørum-Petersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -799,7 +799,7 @@ return [
                                                         [
                                                             'refId' => '981202-03',
                                                             'name' => 'Oliver Geisler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -848,7 +848,7 @@ return [
                                                         [
                                                             'refId' => '011123-05',
                                                             'name' => 'Ellen Møldrup',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -897,7 +897,7 @@ return [
                                                         [
                                                             'refId' => '030628-01',
                                                             'name' => 'Alberte Christensen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -946,7 +946,7 @@ return [
                                                         [
                                                             'refId' => '840707-01',
                                                             'name' => 'Kasper Ipsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -995,7 +995,7 @@ return [
                                                         [
                                                             'refId' => '990407-01',
                                                             'name' => 'Nicklas Scott Larsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1044,7 +1044,7 @@ return [
                                                         [
                                                             'refId' => '960331-07',
                                                             'name' => 'Thomas Jensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1093,7 +1093,7 @@ return [
                                                         [
                                                             'refId' => '991215-05',
                                                             'name' => 'Joakim Vahlkvist',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1142,7 +1142,7 @@ return [
                                                         [
                                                             'refId' => '011123-05',
                                                             'name' => 'Ellen Møldrup',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1183,7 +1183,7 @@ return [
                                                         [
                                                             'refId' => '970512-21',
                                                             'name' => 'Arna Karen Jóhannsdóttir (EU)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1232,7 +1232,7 @@ return [
                                                         [
                                                             'refId' => '040201-01',
                                                             'name' => 'Filippa Ørum-Petersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1273,7 +1273,7 @@ return [
                                                         [
                                                             'refId' => '030628-01',
                                                             'name' => 'Alberte Christensen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1322,7 +1322,7 @@ return [
                                                         [
                                                             'refId' => '011030-01',
                                                             'name' => 'Lasse Ejstrup Brunse',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1363,7 +1363,7 @@ return [
                                                         [
                                                             'refId' => '981202-03',
                                                             'name' => 'Oliver Geisler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1412,7 +1412,7 @@ return [
                                                         [
                                                             'refId' => '990407-01',
                                                             'name' => 'Nicklas Scott Larsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1453,7 +1453,7 @@ return [
                                                         [
                                                             'refId' => '960331-07',
                                                             'name' => 'Thomas Jensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1502,7 +1502,7 @@ return [
                                                         [
                                                             'refId' => '991215-05',
                                                             'name' => 'Joakim Vahlkvist',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1543,7 +1543,7 @@ return [
                                                         [
                                                             'refId' => '840707-01',
                                                             'name' => 'Kasper Ipsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1604,7 +1604,7 @@ return [
                                                         [
                                                             'refId' => '030402-03',
                                                             'name' => 'Pernille Blok',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1645,7 +1645,7 @@ return [
                                                         [
                                                             'refId' => '990112-01',
                                                             'name' => 'Nicklas Vinter Pedersen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1694,7 +1694,7 @@ return [
                                                         [
                                                             'refId' => '060203-03',
                                                             'name' => 'Filippa Kjær Kjellberg',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1735,7 +1735,7 @@ return [
                                                         [
                                                             'refId' => '040111-05',
                                                             'name' => 'Jeppe Boysen-Ebler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1784,7 +1784,7 @@ return [
                                                         [
                                                             'refId' => '040107-01',
                                                             'name' => 'Nicoline Mølgaard',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1833,7 +1833,7 @@ return [
                                                         [
                                                             'refId' => '040220-04',
                                                             'name' => 'Emma Funch Dubery',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1882,7 +1882,7 @@ return [
                                                         [
                                                             'refId' => '050818-04',
                                                             'name' => 'Mads Emil Monke',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1931,7 +1931,7 @@ return [
                                                         [
                                                             'refId' => '020202-1011',
                                                             'name' => 'Martin Kragh',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1980,7 +1980,7 @@ return [
                                                         [
                                                             'refId' => '030218-14',
                                                             'name' => 'Rehan Arshad (udl.)',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2029,7 +2029,7 @@ return [
                                                         [
                                                             'refId' => '040523-02',
                                                             'name' => 'Niklas Lynge Olesen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2078,7 +2078,7 @@ return [
                                                         [
                                                             'refId' => '060203-03',
                                                             'name' => 'Filippa Kjær Kjellberg',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2119,7 +2119,7 @@ return [
                                                         [
                                                             'refId' => '030402-03',
                                                             'name' => 'Pernille Blok',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2168,7 +2168,7 @@ return [
                                                         [
                                                             'refId' => '040107-01',
                                                             'name' => 'Nicoline Mølgaard',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2209,7 +2209,7 @@ return [
                                                         [
                                                             'refId' => '040220-04',
                                                             'name' => 'Emma Funch Dubery',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2258,7 +2258,7 @@ return [
                                                         [
                                                             'refId' => '990112-01',
                                                             'name' => 'Nicklas Vinter Pedersen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2299,7 +2299,7 @@ return [
                                                         [
                                                             'refId' => '050818-04',
                                                             'name' => 'Mads Emil Monke',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2348,7 +2348,7 @@ return [
                                                         [
                                                             'refId' => '030218-14',
                                                             'name' => 'Rehan Arshad (udl.)',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2389,7 +2389,7 @@ return [
                                                         [
                                                             'refId' => '020202-1011',
                                                             'name' => 'Martin Kragh',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2438,7 +2438,7 @@ return [
                                                         [
                                                             'refId' => '040111-05',
                                                             'name' => 'Jeppe Boysen-Ebler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2479,7 +2479,7 @@ return [
                                                         [
                                                             'refId' => '040523-02',
                                                             'name' => 'Niklas Lynge Olesen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>

--- a/tests/GraphQL/CrossSquadsUseCases/usecase4.php
+++ b/tests/GraphQL/CrossSquadsUseCases/usecase4.php
@@ -24,7 +24,7 @@ return [
               [
                 'refId' => '000116-01',
                 'name' => 'Malene Kæseler',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -65,7 +65,7 @@ return [
               [
                 'refId' => '990608-01',
                 'name' => 'Emil Lauritzen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -114,7 +114,7 @@ return [
               [
                 'refId' => '960905-01',
                 'name' => 'Marie Louise Steffensen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -155,7 +155,7 @@ return [
               [
                 'refId' => '940127-05',
                 'name' => 'Frederik Aalestrup',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -204,7 +204,7 @@ return [
               [
                 'refId' => '911123-08',
                 'name' => 'Kathrine Kaack',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -245,7 +245,7 @@ return [
               [
                 'refId' => '000116-01',
                 'name' => 'Malene Kæseler',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -294,7 +294,7 @@ return [
               [
                 'refId' => '961124-13',
                 'name' => 'Ygor Coelho (udl.)',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -343,7 +343,7 @@ return [
               [
                 'refId' => '030116-01',
                 'name' => 'Mads Juel Møller',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -384,7 +384,7 @@ return [
               [
                 'refId' => '960905-01',
                 'name' => 'Marie Louise Steffensen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -425,7 +425,7 @@ return [
               [
                 'refId' => '010626-02',
                 'name' => 'Signe Schulz Terp-Nielsen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -474,7 +474,7 @@ return [
               [
                 'refId' => '940127-05',
                 'name' => 'Frederik Aalestrup',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -515,7 +515,7 @@ return [
               [
                 'refId' => '990608-01',
                 'name' => 'Emil Lauritzen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -564,7 +564,7 @@ return [
               [
                 'refId' => '961124-13',
                 'name' => 'Ygor Coelho (udl.)',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -605,7 +605,7 @@ return [
               [
                 'refId' => '030116-01',
                 'name' => 'Mads Juel Møller',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -658,7 +658,7 @@ return [
               [
                 'refId' => '031125-01',
                 'name' => 'Clara Løber',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -699,7 +699,7 @@ return [
               [
                 'refId' => '050126-01',
                 'name' => 'Mike Vestergaard',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -748,7 +748,7 @@ return [
               [
                 'refId' => '040821-01',
                 'name' => 'Emma Irring Braüner',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -789,7 +789,7 @@ return [
               [
                 'refId' => '050730-01',
                 'name' => 'Calvin Lundsgaard Kvolbæk',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -838,7 +838,7 @@ return [
               [
                 'refId' => '010915-03',
                 'name' => 'Filippa Thyberg',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -887,7 +887,7 @@ return [
               [
                 'refId' => '940119-05',
                 'name' => 'Nanna Vestergaard',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -936,7 +936,7 @@ return [
               [
                 'refId' => '040214-01',
                 'name' => 'Jakob Houe Andersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -985,7 +985,7 @@ return [
               [
                 'refId' => '030530-01',
                 'name' => 'Nikolaj Lassen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1034,7 +1034,7 @@ return [
               [
                 'refId' => '980725-01',
                 'name' => 'Mickey Lykkegren',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1083,7 +1083,7 @@ return [
               [
                 'refId' => '971027-04',
                 'name' => 'Lasse Brund',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1124,7 +1124,7 @@ return [
               [
                 'refId' => '040821-01',
                 'name' => 'Emma Irring Braüner',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1165,7 +1165,7 @@ return [
               [
                 'refId' => '031125-01',
                 'name' => 'Clara Løber',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1214,7 +1214,7 @@ return [
               [
                 'refId' => '940119-05',
                 'name' => 'Nanna Vestergaard',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1255,7 +1255,7 @@ return [
               [
                 'refId' => '010915-03',
                 'name' => 'Filippa Thyberg',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1304,7 +1304,7 @@ return [
               [
                 'refId' => '050730-01',
                 'name' => 'Calvin Lundsgaard Kvolbæk',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1345,7 +1345,7 @@ return [
               [
                 'refId' => '040214-01',
                 'name' => 'Jakob Houe Andersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1394,7 +1394,7 @@ return [
               [
                 'refId' => '050126-01',
                 'name' => 'Mike Vestergaard',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1435,7 +1435,7 @@ return [
               [
                 'refId' => '030530-01',
                 'name' => 'Nikolaj Lassen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1484,7 +1484,7 @@ return [
               [
                 'refId' => '971027-04',
                 'name' => 'Lasse Brund',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1517,7 +1517,7 @@ return [
               [
                 'refId' => '980725-01',
                 'name' => 'Mickey Lykkegren',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1578,7 +1578,7 @@ return [
               [
                 'refId' => '060503-01',
                 'name' => 'Sophia Lemming',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1619,7 +1619,7 @@ return [
               [
                 'refId' => '910611-01',
                 'name' => 'Morten Skrøder Bødskov',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1660,7 +1660,7 @@ return [
               [
                 'refId' => '011206-03',
                 'name' => 'Karoline Asp',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1701,7 +1701,7 @@ return [
               [
                 'refId' => '050312-01',
                 'name' => 'Jacob Bay',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1750,7 +1750,7 @@ return [
               [
                 'refId' => '020722-02',
                 'name' => 'Sophia Bach Graversen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1799,7 +1799,7 @@ return [
               [
                 'refId' => '880721-07',
                 'name' => 'Rikke Nørgaard',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -1848,7 +1848,7 @@ return [
               [
                 'refId' => '060318-01',
                 'name' => 'Lasse Linderoth Pedersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1897,7 +1897,7 @@ return [
               [
                 'refId' => '050521-11',
                 'name' => 'Magnus Hansen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1946,7 +1946,7 @@ return [
               [
                 'refId' => '060203-02',
                 'name' => 'Jakob Clausen Jessen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -1995,7 +1995,7 @@ return [
               [
                 'refId' => '060130-06',
                 'name' => 'Simon Bloch Østergaard',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2044,7 +2044,7 @@ return [
               [
                 'refId' => '020722-02',
                 'name' => 'Sophia Bach Graversen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2085,7 +2085,7 @@ return [
               [
                 'refId' => '060503-01',
                 'name' => 'Sophia Lemming',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2134,7 +2134,7 @@ return [
               [
                 'refId' => '011206-03',
                 'name' => 'Karoline Asp',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2175,7 +2175,7 @@ return [
               [
                 'refId' => '880721-07',
                 'name' => 'Rikke Nørgaard',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2224,7 +2224,7 @@ return [
               [
                 'refId' => '050312-01',
                 'name' => 'Jacob Bay',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2265,7 +2265,7 @@ return [
               [
                 'refId' => '910611-01',
                 'name' => 'Morten Skrøder Bødskov',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2306,7 +2306,7 @@ return [
               [
                 'refId' => '060130-06',
                 'name' => 'Simon Bloch Østergaard',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2347,7 +2347,7 @@ return [
               [
                 'refId' => '060318-01',
                 'name' => 'Lasse Linderoth Pedersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2396,7 +2396,7 @@ return [
               [
                 'refId' => '060203-02',
                 'name' => 'Jakob Clausen Jessen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2437,7 +2437,7 @@ return [
               [
                 'refId' => '050521-11',
                 'name' => 'Magnus Hansen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2498,7 +2498,7 @@ return [
               [
                 'refId' => '880721-07',
                 'name' => 'Rikke Nørgaard',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2539,7 +2539,7 @@ return [
               [
                 'refId' => '831122-01',
                 'name' => 'Morten Møller',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2588,7 +2588,7 @@ return [
               [
                 'refId' => '011206-03',
                 'name' => 'Karoline Asp',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2629,7 +2629,7 @@ return [
               [
                 'refId' => '000601-03',
                 'name' => 'Sebastian Suder',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2678,7 +2678,7 @@ return [
               [
                 'refId' => '040225-08',
                 'name' => 'Sofie Solveig Hansen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2727,7 +2727,7 @@ return [
               [
                 'refId' => '800213-01',
                 'name' => 'Heidi Toft',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -2776,7 +2776,7 @@ return [
               [
                 'refId' => '961004-15',
                 'name' => 'Peter Lauritzen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2825,7 +2825,7 @@ return [
               [
                 'refId' => '900726-22',
                 'name' => 'Thomas Søe Jepsen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2874,7 +2874,7 @@ return [
               [
                 'refId' => '881122-01',
                 'name' => 'Christoffer Vestergaard',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2923,7 +2923,7 @@ return [
               [
                 'refId' => '850115-01',
                 'name' => 'Jens Jørgen Hansen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -2972,7 +2972,7 @@ return [
               [
                 'refId' => '800213-01',
                 'name' => 'Heidi Toft',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -3013,7 +3013,7 @@ return [
               [
                 'refId' => '880721-07',
                 'name' => 'Rikke Nørgaard',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -3062,7 +3062,7 @@ return [
               [
                 'refId' => '040225-08',
                 'name' => 'Sofie Solveig Hansen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -3103,7 +3103,7 @@ return [
               [
                 'refId' => '011206-03',
                 'name' => 'Karoline Asp',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 [
                   0 =>
@@ -3152,7 +3152,7 @@ return [
               [
                 'refId' => '881122-01',
                 'name' => 'Christoffer Vestergaard',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -3193,7 +3193,7 @@ return [
               [
                 'refId' => '900726-22',
                 'name' => 'Thomas Søe Jepsen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -3242,7 +3242,7 @@ return [
               [
                 'refId' => '850115-01',
                 'name' => 'Jens Jørgen Hansen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -3283,7 +3283,7 @@ return [
               [
                 'refId' => '831122-01',
                 'name' => 'Morten Møller',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -3332,7 +3332,7 @@ return [
               [
                 'refId' => '000601-03',
                 'name' => 'Sebastian Suder',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>
@@ -3373,7 +3373,7 @@ return [
               [
                 'refId' => '961004-15',
                 'name' => 'Peter Lauritzen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 [
                   0 =>

--- a/tests/GraphQL/CrossSquadsUseCases/usecase5.php
+++ b/tests/GraphQL/CrossSquadsUseCases/usecase5.php
@@ -24,7 +24,7 @@ return array (
               array (
                 'refId' => '970310-06',
                 'name' => 'Claudia Paredes',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -65,7 +65,7 @@ return array (
               array (
                 'refId' => '971022-01',
                 'name' => 'Tobias Holst-Christensen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -114,7 +114,7 @@ return array (
               array (
                 'refId' => '950821-02',
                 'name' => 'Isabella Nielsen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -155,7 +155,7 @@ return array (
               array (
                 'refId' => '981004-15',
                 'name' => 'Rasmus Kjær Pedersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -204,7 +204,7 @@ return array (
               array (
                 'refId' => '040911-06',
                 'name' => 'Benedicte Sillassen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -253,7 +253,7 @@ return array (
               array (
                 'refId' => '970310-06',
                 'name' => 'Claudia Paredes',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -302,7 +302,7 @@ return array (
               array (
                 'refId' => '020205-02',
                 'name' => 'Axel Henrik Parkhøi',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -351,7 +351,7 @@ return array (
               array (
                 'refId' => '020618-01',
                 'name' => 'Marcus Viscovich',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -400,7 +400,7 @@ return array (
               array (
                 'refId' => '040911-06',
                 'name' => 'Benedicte Sillassen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -441,7 +441,7 @@ return array (
               array (
                 'refId' => '950821-02',
                 'name' => 'Isabella Nielsen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -490,7 +490,7 @@ return array (
               array (
                 'refId' => '981004-15',
                 'name' => 'Rasmus Kjær Pedersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -531,7 +531,7 @@ return array (
               array (
                 'refId' => '971022-01',
                 'name' => 'Tobias Holst-Christensen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -580,7 +580,7 @@ return array (
               array (
                 'refId' => '020205-02',
                 'name' => 'Axel Henrik Parkhøi',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -621,7 +621,7 @@ return array (
               array (
                 'refId' => '020618-01',
                 'name' => 'Marcus Viscovich',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -682,7 +682,7 @@ return array (
               array (
                 'refId' => '870619-02',
                 'name' => 'Marie Røpke',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -723,7 +723,7 @@ return array (
               array (
                 'refId' => '970813-02',
                 'name' => 'Christoffer Voldsgaard Holm',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -772,7 +772,7 @@ return array (
               array (
                 'refId' => '990909-01',
                 'name' => 'Filippa Koch Rohde',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -813,7 +813,7 @@ return array (
               array (
                 'refId' => '990202-01',
                 'name' => 'Tobias Middelbo Eigtved',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -862,7 +862,7 @@ return array (
               array (
                 'refId' => '970630-04',
                 'name' => 'Amalie Hertz',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -903,7 +903,7 @@ return array (
               array (
                 'refId' => '041112-01',
                 'name' => 'Mie Andersson',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -952,7 +952,7 @@ return array (
               array (
                 'refId' => '950323-04',
                 'name' => 'Rasmus Middelbo Eigtved',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1001,7 +1001,7 @@ return array (
               array (
                 'refId' => '060624-01',
                 'name' => 'Mads Andersson',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1050,7 +1050,7 @@ return array (
               array (
                 'refId' => '040526-04',
                 'name' => 'Deepak Pillai',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1099,7 +1099,7 @@ return array (
               array (
                 'refId' => '721015-02',
                 'name' => 'Johnny Hast Hansen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1148,7 +1148,7 @@ return array (
               array (
                 'refId' => '870619-02',
                 'name' => 'Marie Røpke',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1189,7 +1189,7 @@ return array (
               array (
                 'refId' => '990909-01',
                 'name' => 'Filippa Koch Rohde',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1238,7 +1238,7 @@ return array (
               array (
                 'refId' => '970630-04',
                 'name' => 'Amalie Hertz',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1271,7 +1271,7 @@ return array (
               array (
                 'refId' => '041112-01',
                 'name' => 'Mie Andersson',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1320,7 +1320,7 @@ return array (
               array (
                 'refId' => '970813-02',
                 'name' => 'Christoffer Voldsgaard Holm',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1361,7 +1361,7 @@ return array (
               array (
                 'refId' => '950323-04',
                 'name' => 'Rasmus Middelbo Eigtved',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1410,7 +1410,7 @@ return array (
               array (
                 'refId' => '990202-01',
                 'name' => 'Tobias Middelbo Eigtved',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1451,7 +1451,7 @@ return array (
               array (
                 'refId' => '721015-02',
                 'name' => 'Johnny Hast Hansen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1500,7 +1500,7 @@ return array (
               array (
                 'refId' => '040526-04',
                 'name' => 'Deepak Pillai',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1541,7 +1541,7 @@ return array (
               array (
                 'refId' => '060624-01',
                 'name' => 'Mads Andersson',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1602,7 +1602,7 @@ return array (
               array (
                 'refId' => '910425-06',
                 'name' => 'Sophie Kampmann',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1643,7 +1643,7 @@ return array (
               array (
                 'refId' => '801106-01',
                 'name' => 'Henrik Koblauch',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1692,7 +1692,7 @@ return array (
               array (
                 'refId' => '960311-01',
                 'name' => 'Sine Skov Jonassen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1733,7 +1733,7 @@ return array (
               array (
                 'refId' => '900818-23',
                 'name' => 'Rasmus Quist Pedersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1782,7 +1782,7 @@ return array (
               array (
                 'refId' => '940428-09',
                 'name' => 'Julie Rechnagel',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1831,7 +1831,7 @@ return array (
               array (
                 'refId' => '030107-01',
                 'name' => 'Naja Maj Jonassen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -1880,7 +1880,7 @@ return array (
               array (
                 'refId' => '060326-03',
                 'name' => 'William Linnemann Sax',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1929,7 +1929,7 @@ return array (
               array (
                 'refId' => '040824-06',
                 'name' => 'Leander Rostgaard Stender',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -1994,7 +1994,7 @@ return array (
               array (
                 'refId' => '940428-09',
                 'name' => 'Julie Rechnagel',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -2035,7 +2035,7 @@ return array (
               array (
                 'refId' => '910425-06',
                 'name' => 'Sophie Kampmann',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -2084,7 +2084,7 @@ return array (
               array (
                 'refId' => '960311-01',
                 'name' => 'Sine Skov Jonassen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -2125,7 +2125,7 @@ return array (
               array (
                 'refId' => '030107-01',
                 'name' => 'Naja Maj Jonassen',
-                'gender' => 'K',
+                'gender' => 'WOMEN',
                 'points' =>
                 array (
                   0 =>
@@ -2174,7 +2174,7 @@ return array (
               array (
                 'refId' => '900818-23',
                 'name' => 'Rasmus Quist Pedersen',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -2215,7 +2215,7 @@ return array (
               array (
                 'refId' => '801106-01',
                 'name' => 'Henrik Koblauch',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -2264,7 +2264,7 @@ return array (
               array (
                 'refId' => '060326-03',
                 'name' => 'William Linnemann Sax',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>
@@ -2305,7 +2305,7 @@ return array (
               array (
                 'refId' => '040824-06',
                 'name' => 'Leander Rostgaard Stender',
-                'gender' => 'M',
+                'gender' => 'MEN',
                 'points' =>
                 array (
                   0 =>

--- a/tests/GraphQL/SquadsUseCases/usecase1.php
+++ b/tests/GraphQL/SquadsUseCases/usecase1.php
@@ -23,7 +23,7 @@ return [
                                                         [
                                                             'refId' => '980823-03',
                                                             'name' => 'Lisa Kramer',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -56,7 +56,7 @@ return [
                                                         [
                                                             'refId' => '980920-02',
                                                             'name' => 'Rasmus Kæseler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -105,7 +105,7 @@ return [
                                                         [
                                                             'refId' => '031227-01',
                                                             'name' => 'Vibse Jonassen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -146,7 +146,7 @@ return [
                                                         [
                                                             'refId' => '930813-29',
                                                             'name' => 'Wong Fai Yin (Udl.)',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -195,7 +195,7 @@ return [
                                                         [
                                                             'refId' => '021103-01',
                                                             'name' => 'Laura Fløj Thomsen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -244,7 +244,7 @@ return [
                                                         [
                                                             'refId' => '960830-22',
                                                             'name' => 'Sabrina Solis (udl.)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -293,7 +293,7 @@ return [
                                                         [
                                                             'refId' => '940720-01',
                                                             'name' => 'Mads Emil Kristensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -342,7 +342,7 @@ return [
                                                         [
                                                             'refId' => '020325-02',
                                                             'name' => 'Mathias Solgaard',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -391,7 +391,7 @@ return [
                                                         [
                                                             'refId' => '031227-01',
                                                             'name' => 'Vibse Jonassen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -432,7 +432,7 @@ return [
                                                         [
                                                             'refId' => '980823-03',
                                                             'name' => 'Lisa Kramer',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -473,7 +473,7 @@ return [
                                                         [
                                                             'refId' => '980920-02',
                                                             'name' => 'Rasmus Kæseler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -514,7 +514,7 @@ return [
                                                         [
                                                             'refId' => '940720-01',
                                                             'name' => 'Mads Emil Kristensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -563,7 +563,7 @@ return [
                                                         [
                                                             'refId' => '020325-02',
                                                             'name' => 'Mathias Solgaard',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -604,7 +604,7 @@ return [
                                                         [
                                                             'refId' => '930813-29',
                                                             'name' => 'Wong Fai Yin (Udl.)',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -664,7 +664,7 @@ return [
                                                         [
                                                             'refId' => '970512-21',
                                                             'name' => 'Arna Karen Jóhannsdóttir (EU)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -705,7 +705,7 @@ return [
                                                         [
                                                             'refId' => '981202-03',
                                                             'name' => 'Oliver Geisler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -754,7 +754,7 @@ return [
                                                         [
                                                             'refId' => '040201-01',
                                                             'name' => 'Filippa Ørum-Petersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -795,7 +795,7 @@ return [
                                                         [
                                                             'refId' => '011030-01',
                                                             'name' => 'Lasse Ejstrup Brunse',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -844,7 +844,7 @@ return [
                                                         [
                                                             'refId' => '011123-05',
                                                             'name' => 'Ellen Møldrup',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -893,7 +893,7 @@ return [
                                                         [
                                                             'refId' => '030628-01',
                                                             'name' => 'Alberte Christensen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -942,7 +942,7 @@ return [
                                                         [
                                                             'refId' => '990407-01',
                                                             'name' => 'Nicklas Scott Larsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -991,7 +991,7 @@ return [
                                                         [
                                                             'refId' => '050818-04',
                                                             'name' => 'Mads Emil Monke',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1040,7 +1040,7 @@ return [
                                                         [
                                                             'refId' => '020206-01',
                                                             'name' => 'Benjamin Illum Klindt',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1089,7 +1089,7 @@ return [
                                                         [
                                                             'refId' => '960331-07',
                                                             'name' => 'Thomas Jensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1138,7 +1138,7 @@ return [
                                                         [
                                                             'refId' => '040201-01',
                                                             'name' => 'Filippa Ørum-Petersen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1179,7 +1179,7 @@ return [
                                                         [
                                                             'refId' => '970512-21',
                                                             'name' => 'Arna Karen Jóhannsdóttir (EU)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1228,7 +1228,7 @@ return [
                                                         [
                                                             'refId' => '011123-05',
                                                             'name' => 'Ellen Møldrup',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1269,7 +1269,7 @@ return [
                                                         [
                                                             'refId' => '030628-01',
                                                             'name' => 'Alberte Christensen',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1318,7 +1318,7 @@ return [
                                                         [
                                                             'refId' => '011030-01',
                                                             'name' => 'Lasse Ejstrup Brunse',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1359,7 +1359,7 @@ return [
                                                         [
                                                             'refId' => '020206-01',
                                                             'name' => 'Benjamin Illum Klindt',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1408,7 +1408,7 @@ return [
                                                         [
                                                             'refId' => '981202-03',
                                                             'name' => 'Oliver Geisler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1449,7 +1449,7 @@ return [
                                                         [
                                                             'refId' => '050818-04',
                                                             'name' => 'Mads Emil Monke',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1498,7 +1498,7 @@ return [
                                                         [
                                                             'refId' => '990407-01',
                                                             'name' => 'Nicklas Scott Larsen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1539,7 +1539,7 @@ return [
                                                         [
                                                             'refId' => '960331-07',
                                                             'name' => 'Thomas Jensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1599,7 +1599,7 @@ return [
                                                         [
                                                             'refId' => '060203-03',
                                                             'name' => 'Filippa Kjær Kjellberg',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1640,7 +1640,7 @@ return [
                                                         [
                                                             'refId' => '991215-05',
                                                             'name' => 'Joakim Vahlkvist',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1689,7 +1689,7 @@ return [
                                                         [
                                                             'refId' => '040107-01',
                                                             'name' => 'Nicoline Mølgaard',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1730,7 +1730,7 @@ return [
                                                         [
                                                             'refId' => '040111-05',
                                                             'name' => 'Jeppe Boysen-Ebler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1779,7 +1779,7 @@ return [
                                                         [
                                                             'refId' => '040331-21',
                                                             'name' => 'Michaela Telehanicova (EU)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1828,7 +1828,7 @@ return [
                                                         [
                                                             'refId' => '040220-04',
                                                             'name' => 'Emma Funch Dubery',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1877,7 +1877,7 @@ return [
                                                         [
                                                             'refId' => '020202-1011',
                                                             'name' => 'Martin Kragh',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1926,7 +1926,7 @@ return [
                                                         [
                                                             'refId' => '030610-05',
                                                             'name' => 'Emil Bunch Christensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -1975,7 +1975,7 @@ return [
                                                         [
                                                             'refId' => '050805-07',
                                                             'name' => 'William Adrian Abildtrup',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2024,7 +2024,7 @@ return [
                                                         [
                                                             'refId' => '040523-02',
                                                             'name' => 'Niklas Lynge Olesen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2073,7 +2073,7 @@ return [
                                                         [
                                                             'refId' => '040107-01',
                                                             'name' => 'Nicoline Mølgaard',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2114,7 +2114,7 @@ return [
                                                         [
                                                             'refId' => '040331-21',
                                                             'name' => 'Michaela Telehanicova (EU)',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2163,7 +2163,7 @@ return [
                                                         [
                                                             'refId' => '040220-04',
                                                             'name' => 'Emma Funch Dubery',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2204,7 +2204,7 @@ return [
                                                         [
                                                             'refId' => '060203-03',
                                                             'name' => 'Filippa Kjær Kjellberg',
-                                                            'gender' => 'K',
+                                                            'gender' => 'WOMEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2253,7 +2253,7 @@ return [
                                                         [
                                                             'refId' => '040111-05',
                                                             'name' => 'Jeppe Boysen-Ebler',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2294,7 +2294,7 @@ return [
                                                         [
                                                             'refId' => '991215-05',
                                                             'name' => 'Joakim Vahlkvist',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2343,7 +2343,7 @@ return [
                                                         [
                                                             'refId' => '020202-1011',
                                                             'name' => 'Martin Kragh',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2384,7 +2384,7 @@ return [
                                                         [
                                                             'refId' => '030610-05',
                                                             'name' => 'Emil Bunch Christensen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2433,7 +2433,7 @@ return [
                                                         [
                                                             'refId' => '040523-02',
                                                             'name' => 'Niklas Lynge Olesen',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>
@@ -2474,7 +2474,7 @@ return [
                                                         [
                                                             'refId' => '050805-07',
                                                             'name' => 'William Adrian Abildtrup',
-                                                            'gender' => 'M',
+                                                            'gender' => 'MEN',
                                                             'points' =>
                                                                 [
                                                                     0 =>

--- a/tests/GraphQL/ValidateCrossSquadsLeagueTest.php
+++ b/tests/GraphQL/ValidateCrossSquadsLeagueTest.php
@@ -319,7 +319,7 @@ class ValidateCrossSquadsLeagueTest extends BaseTestCase
                          [
                              'refId'    => $women1->refId,
                              'category' => 'Dummy-stuff',
-                             'gender'   => 'K',
+                             'gender'   => 'WOMEN',
                              'belowPlayer' => [
                                  [
                                      'refId'    => $womenSpecial2->refId,
@@ -517,7 +517,7 @@ class ValidateCrossSquadsLeagueTest extends BaseTestCase
                          [
                              'refId' => $women1->refId,
                              'category' => 'Dummy-stuff',
-                             'gender'  => 'K',
+                             'gender'  => 'WOMEN',
                              'belowPlayer' => [
                                  [
                                      'refId'    => $womenSpecial1->refId,

--- a/tests/GraphQL/ValidateCrossSquadsTest.php
+++ b/tests/GraphQL/ValidateCrossSquadsTest.php
@@ -932,7 +932,7 @@ class ValidateCrossSquadsTest extends BaseTestCase
                      'validateCrossSquads' => [
                          [
                              'refId'       => $women1->refId,
-                             'gender'      => 'K',
+                             'gender'      => 'WOMEN',
                              'belowPlayer' => [
                                  [
                                      'refId'    => $squad1Women2->refId,
@@ -1127,7 +1127,7 @@ class ValidateCrossSquadsTest extends BaseTestCase
                                  ],
                              ],
                              'refId'       => $women1->refId,
-                             'gender'      => 'K',
+                             'gender'      => 'WOMEN',
                          ],
                      ],
                  ],
@@ -1374,7 +1374,7 @@ class ValidateCrossSquadsTest extends BaseTestCase
                      'validateCrossSquads' => [
                          [
                              'refId'       => $men1->refId,
-                             'gender'      => 'M',
+                             'gender'      => 'MEN',
                              'belowPlayer' => [
                                  [
                                      'category' => 'MxH',
@@ -1388,7 +1388,7 @@ class ValidateCrossSquadsTest extends BaseTestCase
                          ],
                          [
                              'refId'       => $men2->refId,
-                             'gender'      => 'M',
+                             'gender'      => 'MEN',
                              'belowPlayer' => [
                                  [
                                      'category' => 'MxH',

--- a/tests/GraphQL/ValidateSquadTest.php
+++ b/tests/GraphQL/ValidateSquadTest.php
@@ -49,10 +49,10 @@ class ValidateSquadTest extends BaseTestCase
         )->assertExactJson([
             'data' => [
                 'validateSquads' => [
-                    ["category"=>"HD","gender"=>"M","refId"=>"020202-1011"],
-                    ["category"=>"HD","gender"=>"M","refId"=>"030610-05"],
-                    ["category"=>"DD","gender"=>"K","refId"=>"040201-01"],
-                    ["category"=>"DD","gender"=>"K","refId"=>"970512-21"]
+                    ["category"=>"HD","gender"=>"MEN","refId"=>"020202-1011"],
+                    ["category"=>"HD","gender"=>"MEN","refId"=>"030610-05"],
+                    ["category"=>"DD","gender"=>"WOMEN","refId"=>"040201-01"],
+                    ["category"=>"DD","gender"=>"WOMEN","refId"=>"970512-21"]
                 ]
             ],
             'extensions' => [
@@ -123,12 +123,12 @@ class ValidateSquadTest extends BaseTestCase
                         [
                             'refId' => $women1->refId,
                             'category' => 'MD',
-                            'gender' => 'K'
+                            'gender' => 'WOMEN'
                         ],
                         [
                             'refId' => $men1->refId,
                             'category' => 'MD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ]
                     ]
                 ],
@@ -200,17 +200,17 @@ class ValidateSquadTest extends BaseTestCase
                         [
                             'refId' => $men3->refId,
                             'category' => 'HS',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men4->refId,
                             'category' => 'HS',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men5->refId,
                             'category' => 'HS',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                     ]
                 ],
@@ -282,22 +282,22 @@ class ValidateSquadTest extends BaseTestCase
                         [
                             'refId' => $men1->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men2->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men3->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men4->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                     ]
                 ],
@@ -369,32 +369,32 @@ class ValidateSquadTest extends BaseTestCase
                         [
                             'refId' => $women1->refId,
                             'category' => 'MD',
-                            'gender' => 'K'
+                            'gender' => 'WOMEN'
                         ],
                         [
                             'refId' => $men1->refId,
                             'category' => 'MD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men1->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men2->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men3->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                         [
                             'refId' => $men4->refId,
                             'category' => 'HD',
-                            'gender' => 'M'
+                            'gender' => 'MEN'
                         ],
                     ]
                 ],
@@ -510,7 +510,7 @@ class ValidateSquadTest extends BaseTestCase
                          [
                              'refId' => $men3->refId,
                              'category' => 'HS',
-                             'gender' => 'M'
+                             'gender' => 'MEN'
                          ]
                      ]
                  ],


### PR DESCRIPTION
Refactor the gender field type from String to Enum type Gender across GraphQL schemas and update Vue components to align with the new type. Simplify member point import logic by removing redundant checks and add functionalities to handle member upsert operations more efficiently.