### PR TITLE
Rename teams table to team_rounds

### DIFF
--- a/app/Models/TeamRound.php
+++ b/app/Models/TeamRound.php
@@ -15,8 +15,6 @@ class TeamRound extends Model
 {
     use HasFactory;
 
-    protected $table = 'team_rounds';
-
     public    $incrementing = false;
 
     protected $fillable     = ['teams', 'name', 'game_date', 'version', 'round', 'user_id', 'clubhouse_id'];

--- a/app/Models/TeamRound.php
+++ b/app/Models/TeamRound.php
@@ -15,7 +15,7 @@ class TeamRound extends Model
 {
     use HasFactory;
 
-    protected $table = 'teams';
+    protected $table = 'team_rounds';
 
     public    $incrementing = false;
 

--- a/database/migrations/2026_04_25_120000_rename_teams_table_to_team_rounds.php
+++ b/database/migrations/2026_04_25_120000_rename_teams_table_to_team_rounds.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::rename('teams', 'team_rounds');
+    }
+
+    public function down(): void
+    {
+        Schema::rename('team_rounds', 'teams');
+    }
+};

--- a/database/seeds/TeamFightSeeder.php
+++ b/database/seeds/TeamFightSeeder.php
@@ -19,7 +19,7 @@ class TeamFightSeeder extends Seeder
     {
         $data = require __DIR__ . '/team_fights_data.php';
 
-        DB::table('teams')->insert($data['teams']);
+        DB::table('team_rounds')->insert($data['teams']);
 
         foreach (array_chunk($data['squads'], 100) as $chunk) {
             DB::table('squads')->insert($chunk);

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -263,7 +263,7 @@ class TeamsTest extends TestCase
             ]
         ]);
 
-        $this->assertDatabaseHas('teams', [
+        $this->assertDatabaseHas('team_rounds', [
             'name' => 'New Team',
             'clubhouse_id' => $clubhouse->id,
             'user_id' => $user->id
@@ -311,7 +311,7 @@ class TeamsTest extends TestCase
             ]
         ]);
 
-        $this->assertDatabaseHas('teams', [
+        $this->assertDatabaseHas('team_rounds', [
             'id' => $teamRound->id,
             'name' => 'Updated Name'
         ]);
@@ -350,7 +350,7 @@ class TeamsTest extends TestCase
             ]
         ]);
 
-        $this->assertDatabaseMissing('teams', [
+        $this->assertDatabaseMissing('team_rounds', [
             'id' => $teamRound->id
         ]);
     }
@@ -390,7 +390,7 @@ class TeamsTest extends TestCase
             ]
         ]);
 
-        $this->assertDatabaseHas('teams', [
+        $this->assertDatabaseHas('team_rounds', [
             'name' => 'Kopi af Original Team',
             'clubhouse_id' => $clubhouse->id
         ]);
@@ -525,7 +525,7 @@ class TeamsTest extends TestCase
             ]
         ]);
 
-        $this->assertDatabaseHas('teams', [
+        $this->assertDatabaseHas('team_rounds', [
             'id' => $teamRound->id,
             'version' => '2023-01-01'
         ]);


### PR DESCRIPTION
## Summary
- add a migration to rename the `teams` table to `team_rounds`
- update `TeamRound` model to use `team_rounds`
- update direct table references in seeding and GraphQL DB assertions

## Testing
- `docker compose run --rm artisan test tests/GraphQL/TeamsTest.php`