### PR TITLE
Rename squads teams_id to team_round_id

### DIFF
--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -94,7 +94,7 @@ class Member extends Model
     public function scopeNotOnSquad(Builder $builder, string $teamId) : Builder
     {
         return $builder->whereDoesntHave('squadMember.category.squad', function (Builder $builder) use ($teamId) {
-            $builder->where('teams_id', '=', $teamId);
+            $builder->where('team_round_id', '=', $teamId);
         });
     }
 

--- a/app/Models/Squad.php
+++ b/app/Models/Squad.php
@@ -17,7 +17,7 @@ use Spatie\EloquentSortable\SortableTrait;
  * @property int                        $id
  * @property Collection|SquadCategory[] $categories
  * @property TeamRound                  $team
- * @property int                        $teams_id
+ * @property string                     $team_round_id
  * @property int                        $order
  * @property int|null                   $external_team_fight_id
  * @property Carbon|null                $playing_datetime
@@ -46,7 +46,7 @@ class Squad extends Model implements Sortable
         'playerLimit',
         'league',
         'order',
-        'teams_id',
+        'team_round_id',
         'name',
         'external_team_fight_id',
         'playing_datetime',
@@ -59,7 +59,7 @@ class Squad extends Model implements Sortable
 
     public function buildSortQuery() : \Illuminate\Database\Eloquent\Builder
     {
-        return static::query()->where('teams_id', $this->teams_id);
+        return static::query()->where('team_round_id', $this->team_round_id);
     }
 
     public function categories() : hasMany
@@ -69,6 +69,6 @@ class Squad extends Model implements Sortable
 
     public function team() : BelongsTo
     {
-        return $this->belongsTo(TeamRound::class, 'teams_id');
+        return $this->belongsTo(TeamRound::class, 'team_round_id');
     }
 }

--- a/app/Models/TeamRound.php
+++ b/app/Models/TeamRound.php
@@ -60,6 +60,6 @@ class TeamRound extends Model
 
     public function squads() : HasMany
     {
-        return $this->hasMany(Squad::class, 'teams_id', 'id')->orderBy('order');
+        return $this->hasMany(Squad::class, 'team_round_id', 'id')->orderBy('order');
     }
 }

--- a/database/migrations/2026_04_25_130000_rename_squads_teams_id_to_team_round_id.php
+++ b/database/migrations/2026_04_25_130000_rename_squads_teams_id_to_team_round_id.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('squads', function (Blueprint $table) {
+            $table->dropForeign(['teams_id']);
+            $table->renameColumn('teams_id', 'team_round_id');
+        });
+
+        Schema::table('squads', function (Blueprint $table) {
+            $table->foreign('team_round_id')->references('id')->on('team_rounds')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('squads', function (Blueprint $table) {
+            $table->dropForeign(['team_round_id']);
+            $table->renameColumn('team_round_id', 'teams_id');
+        });
+
+        Schema::table('squads', function (Blueprint $table) {
+            $table->foreign('teams_id')->references('id')->on('team_rounds')->cascadeOnDelete();
+        });
+    }
+};

--- a/database/seeds/team_fights_data.php
+++ b/database/seeds/team_fights_data.php
@@ -24,18 +24,18 @@ return [
 
     // ── squads table ──
     "squads" => [
-        ["id" => 1, "playerLimit" => 10, "teams_id" => "OwcAGQZ8M0dEhtap6Cn2vPrL", "league" => "OTHER", "order" => 1],
-        ["id" => 2, "playerLimit" => 10, "teams_id" => "OwcAGQZ8M0dEhtap6Cn2vPrL", "league" => "OTHER", "order" => 2],
-        ["id" => 3, "playerLimit" => 10, "teams_id" => "OwcAGQZ8M0dEhtap6Cn2vPrL", "league" => "OTHER", "order" => 3],
-        ["id" => 4, "playerLimit" => 10, "teams_id" => "YoeIdBfDEwuq0La74WjOcKs9", "league" => "OTHER", "order" => 1],
-        ["id" => 5, "playerLimit" => 10, "teams_id" => "YoeIdBfDEwuq0La74WjOcKs9", "league" => "OTHER", "order" => 2],
-        ["id" => 6, "playerLimit" => 10, "teams_id" => "YoeIdBfDEwuq0La74WjOcKs9", "league" => "OTHER", "order" => 3],
-        ["id" => 7, "playerLimit" => 10, "teams_id" => "Vp9CWTb5aDxZoXcSmnw3YqtL", "league" => "OTHER", "order" => 1],
-        ["id" => 8, "playerLimit" => 10, "teams_id" => "Vp9CWTb5aDxZoXcSmnw3YqtL", "league" => "OTHER", "order" => 2],
-        ["id" => 9, "playerLimit" => 10, "teams_id" => "Vp9CWTb5aDxZoXcSmnw3YqtL", "league" => "OTHER", "order" => 3],
-        ["id" => 10, "playerLimit" => 10, "teams_id" => "NKYyhglC5ai7pTz6IsFqQb1k", "league" => "OTHER", "order" => 1],
-        ["id" => 11, "playerLimit" => 10, "teams_id" => "NKYyhglC5ai7pTz6IsFqQb1k", "league" => "OTHER", "order" => 2],
-        ["id" => 12, "playerLimit" => 10, "teams_id" => "NKYyhglC5ai7pTz6IsFqQb1k", "league" => "OTHER", "order" => 3],
+        ["id" => 1, "playerLimit" => 10, "team_round_id" => "OwcAGQZ8M0dEhtap6Cn2vPrL", "league" => "OTHER", "order" => 1],
+        ["id" => 2, "playerLimit" => 10, "team_round_id" => "OwcAGQZ8M0dEhtap6Cn2vPrL", "league" => "OTHER", "order" => 2],
+        ["id" => 3, "playerLimit" => 10, "team_round_id" => "OwcAGQZ8M0dEhtap6Cn2vPrL", "league" => "OTHER", "order" => 3],
+        ["id" => 4, "playerLimit" => 10, "team_round_id" => "YoeIdBfDEwuq0La74WjOcKs9", "league" => "OTHER", "order" => 1],
+        ["id" => 5, "playerLimit" => 10, "team_round_id" => "YoeIdBfDEwuq0La74WjOcKs9", "league" => "OTHER", "order" => 2],
+        ["id" => 6, "playerLimit" => 10, "team_round_id" => "YoeIdBfDEwuq0La74WjOcKs9", "league" => "OTHER", "order" => 3],
+        ["id" => 7, "playerLimit" => 10, "team_round_id" => "Vp9CWTb5aDxZoXcSmnw3YqtL", "league" => "OTHER", "order" => 1],
+        ["id" => 8, "playerLimit" => 10, "team_round_id" => "Vp9CWTb5aDxZoXcSmnw3YqtL", "league" => "OTHER", "order" => 2],
+        ["id" => 9, "playerLimit" => 10, "team_round_id" => "Vp9CWTb5aDxZoXcSmnw3YqtL", "league" => "OTHER", "order" => 3],
+        ["id" => 10, "playerLimit" => 10, "team_round_id" => "NKYyhglC5ai7pTz6IsFqQb1k", "league" => "OTHER", "order" => 1],
+        ["id" => 11, "playerLimit" => 10, "team_round_id" => "NKYyhglC5ai7pTz6IsFqQb1k", "league" => "OTHER", "order" => 2],
+        ["id" => 12, "playerLimit" => 10, "team_round_id" => "NKYyhglC5ai7pTz6IsFqQb1k", "league" => "OTHER", "order" => 3],
     ],
 
     // ── squad_categories table ──

--- a/local-vendor/team-fight/src/SquadManager.php
+++ b/local-vendor/team-fight/src/SquadManager.php
@@ -37,7 +37,7 @@ class SquadManager
             })->find($squadInput->id);
             if($squad === null){
                 $squad = new SquadModel(['playerLimit' => $squadInput->playerLimit, 'league' => $squadInput->league, 'order' => $index]);
-                $squad->forceFill(['teams_id' => $team->id]);
+                $squad->forceFill(['team_round_id' => $team->id]);
                 $squad->saveOrFail();
             }else{
                 $squad->updateOrFail(['playerLimit' => $squadInput->playerLimit, 'league' => $squadInput->league, 'order' => $index]);

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -442,7 +442,7 @@ class TeamsTest extends TestCase
         ]);
 
         $this->assertDatabaseHas('squads', [
-            'teams_id' => $teamRound->id,
+            'team_round_id' => $teamRound->id,
             'playerLimit' => 10
         ]);
     }

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -5,6 +5,11 @@ namespace Tests\GraphQL;
 use App\Enums\Permission;
 use App\Enums\RecipientType;
 use App\Models\Clubhouse;
+use App\Models\Member;
+use App\Models\Point;
+use App\Models\Squad;
+use App\Models\SquadCategory;
+use App\Models\SquadMember;
 use App\Models\TeamActivityLog;
 use App\Models\TeamReceivers;
 use App\Models\TeamRound;
@@ -444,6 +449,449 @@ class TeamsTest extends TestCase
         $this->assertDatabaseHas('squads', [
             'team_round_id' => $teamRound->id,
             'playerLimit' => 10
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_update_a_squad()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+        $squad = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($input: UpdateSquadInput!) {
+                updateSquad(input: $input) {
+                    id
+                    playerLimit
+                    league
+                    name
+                    playingPlace
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $squad->id,
+                'playerLimit' => 12,
+                'league' => 'LIGA',
+                'name' => 'Updated Squad',
+                'playingPlace' => 'Main Hall',
+            ]
+        ])->assertJson([
+            'data' => [
+                'updateSquad' => [
+                    'id' => (string)$squad->id,
+                    'playerLimit' => 12,
+                    'league' => 'LIGA',
+                    'name' => 'Updated Squad',
+                    'playingPlace' => 'Main Hall',
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseHas('squads', [
+            'id' => $squad->id,
+            'playerLimit' => 12,
+            'league' => 'LIGA',
+            'name' => 'Updated Squad',
+            'playing_place' => 'Main Hall',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_delete_a_squad()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+        $squad = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($id: ID!) {
+                deleteSquad(id: $id) {
+                    id
+                }
+            }
+        ', [
+            'id' => $squad->id,
+        ])->assertJson([
+            'data' => [
+                'deleteSquad' => [
+                    'id' => (string)$squad->id,
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseMissing('squads', [
+            'id' => $squad->id,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_move_squad_order_up()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+        $first = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+        $second = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 2,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($id: ID!) {
+                moveSquadOrderUp(id: $id) {
+                    id
+                }
+            }
+        ', [
+            'id' => $second->id,
+        ])->assertJson([
+            'data' => [
+                'moveSquadOrderUp' => [
+                    'id' => (string)$second->id,
+                ]
+            ]
+        ]);
+
+        $first->refresh();
+        $second->refresh();
+
+        $this->assertSame(2, $first->order);
+        $this->assertSame(1, $second->order);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_move_squad_order_down()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+        $first = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+        $second = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 2,
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($id: ID!) {
+                moveSquadOrderDown(id: $id) {
+                    id
+                }
+            }
+        ', [
+            'id' => $first->id,
+        ])->assertJson([
+            'data' => [
+                'moveSquadOrderDown' => [
+                    'id' => (string)$first->id,
+                ]
+            ]
+        ]);
+
+        $first->refresh();
+        $second->refresh();
+
+        $this->assertSame(2, $first->order);
+        $this->assertSame(1, $second->order);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_a_squad_member_by_ref_id()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+        $squad = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+        $category = $squad->categories()->create([
+            'category' => 'HS',
+            'name' => '1. HS',
+        ]);
+
+        $member = Member::query()->create([
+            'refId' => '9001011234',
+            'name' => 'Member Player',
+            'gender' => 'M',
+            'birthday' => '1990-01-01',
+            'playable' => true,
+            'inactive' => false,
+        ]);
+        Point::query()->create([
+            'member_id' => $member->id,
+            'points' => 100,
+            'position' => 1,
+            'category' => 'HS',
+            'vintage' => 'SEN',
+            'version' => '2024-01-01',
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($input: AddSquadMemberByRefIdInput!) {
+                addSquadMemberByRefId(input: $input) {
+                    id
+                    refId
+                    name
+                    points {
+                        points
+                        category
+                    }
+                }
+            }
+        ', [
+            'input' => [
+                'refId' => $member->refId,
+                'categoryId' => $category->id,
+                'version' => '2024-01-01',
+            ]
+        ])->assertJson([
+            'data' => [
+                'addSquadMemberByRefId' => [
+                    'refId' => $member->refId,
+                    'name' => 'Member Player',
+                    'points' => [
+                        [
+                            'points' => 100,
+                            'category' => 'HS',
+                        ]
+                    ],
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseHas('squad_members', [
+            'member_ref_id' => $member->refId,
+            'squad_category_id' => $category->id,
+            'name' => 'Member Player',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_update_a_squad_member()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+        $squad = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+        $category = $squad->categories()->create([
+            'category' => 'HS',
+            'name' => '1. HS',
+        ]);
+        Member::query()->create([
+            'refId' => '9001011234',
+            'name' => 'Member Player',
+            'gender' => 'M',
+            'birthday' => '1990-01-01',
+            'playable' => true,
+            'inactive' => false,
+        ]);
+        $squadMember = SquadMember::query()->create([
+            'member_ref_id' => '9001011234',
+            'squad_category_id' => $category->id,
+            'name' => 'Member Player',
+            'gender' => 'M',
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($input: UpdateSquadMemberInput!) {
+                updateSquadMember(input: $input) {
+                    id
+                    points {
+                        points
+                        category
+                        position
+                        corrected_manually
+                    }
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $squadMember->id,
+                'points' => [
+                    'create' => [
+                        [
+                            'category' => 'HS',
+                            'points' => 77,
+                            'position' => 2,
+                            'vintage' => 'SEN',
+                            'corrected_manually' => true,
+                            'version' => '2024-01-01',
+                        ],
+                    ],
+                ],
+            ],
+        ])->assertJsonFragment([
+            'id' => (string)$squadMember->id,
+            'points' => 77,
+            'category' => 'HS',
+            'position' => 2,
+            'corrected_manually' => true,
+        ]);
+
+        $this->assertDatabaseHas('squad_points', [
+            'squad_member_id' => $squadMember->id,
+            'points' => 77,
+            'category' => 'HS',
+            'position' => 2,
+            'vintage' => 'SEN',
+            'corrected_manually' => true,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_delete_a_squad_member()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+        $squad = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+        $category = $squad->categories()->create([
+            'category' => 'HS',
+            'name' => '1. HS',
+        ]);
+        Member::query()->create([
+            'refId' => '9001011234',
+            'name' => 'Member Player',
+            'gender' => 'M',
+            'birthday' => '1990-01-01',
+            'playable' => true,
+            'inactive' => false,
+        ]);
+        $squadMember = SquadMember::query()->create([
+            'member_ref_id' => '9001011234',
+            'squad_category_id' => $category->id,
+            'name' => 'Member Player',
+            'gender' => 'M',
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($id: ID!) {
+                deleteSquadMember(id: $id) {
+                    id
+                }
+            }
+        ', [
+            'id' => $squadMember->id,
+        ])->assertJson([
+            'data' => [
+                'deleteSquadMember' => [
+                    'id' => (string)$squadMember->id,
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseMissing('squad_members', [
+            'id' => $squadMember->id,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add a migration to rename `squads.teams_id` to `squads.team_round_id`
- update squad/team-round relations and related queries to use `team_round_id`
- update team-fight seeder fixture keys and GraphQL DB assertion to `team_round_id`
- update local team-fight `SquadManager` write path to fill `team_round_id`

## Testing
- `docker compose run --rm artisan test tests/GraphQL/TeamsTest.php`
- `docker compose run --rm artisan test tests/GraphQL/ValidateBasicSquadTest.php`
- `docker compose run --rm artisan test tests/GraphQL/ValidateSquadTest.php`
