### PR TITLE
Rename team receiver/activity log FK to team_round_id

### DIFF
--- a/app/Models/TeamActivityLog.php
+++ b/app/Models/TeamActivityLog.php
@@ -13,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int     $id
- * @property string  $team_id
+ * @property string  $team_round_id
  * @property string  $action
  * @property string  $recipient_type
  * @property int     $recipient_count
@@ -29,7 +29,7 @@ class TeamActivityLog extends Model
     use HasFactory;
 
     protected $fillable = [
-        'team_id',
+        'team_round_id',
         'action',
         'recipient_type',
         'recipient_count',
@@ -50,7 +50,7 @@ class TeamActivityLog extends Model
      */
     public function team(): BelongsTo
     {
-        return $this->belongsTo(TeamRound::class, 'team_id');
+        return $this->belongsTo(TeamRound::class, 'team_round_id');
     }
 
     /**
@@ -90,7 +90,7 @@ class TeamActivityLog extends Model
         ?int $userId = null
     ): self {
         return self::create([
-            'team_id' => $teamId,
+            'team_round_id' => $teamId,
             'action' => ActivityAction::TEAM_PUBLISH,
             'recipient_type' => $recipientType,
             'recipient_count' => $recipientCount,
@@ -117,7 +117,7 @@ class TeamActivityLog extends Model
         ?int $userId = null
     ): self {
         return self::create([
-            'team_id' => $teamId,
+            'team_round_id' => $teamId,
             'action' => ActivityAction::TEST_EMAIL_SENT,
             'recipient_type' => $recipientType,
             'recipient_count' => 1,

--- a/app/Models/TeamReceivers.php
+++ b/app/Models/TeamReceivers.php
@@ -12,18 +12,23 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * belongsTo relationship with the Teams model.
  *
  * @property int $id The primary key of the TeamReceivers table.
- * @property int $team_id The ID of the associated team.
+ * @property string $team_round_id The ID of the associated team round.
  * @property array $emails A JSON-encoded array of email addresses.
  *
  */
 class TeamReceivers extends Model
 {
 
-    protected $fillable = ['team_id','emails'];
+    protected $fillable = ['team_round_id','emails'];
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(TeamRound::class, 'team_round_id');
+    }
 
     public function teams(): BelongsTo
     {
-        return $this->belongsTo(TeamRound::class, 'team_id');
+        return $this->team();
     }
 
     protected function casts(): array

--- a/app/Models/TeamRound.php
+++ b/app/Models/TeamRound.php
@@ -50,12 +50,12 @@ class TeamRound extends Model
 
     public function receiver() : HasOne
     {
-        return $this->hasOne(TeamReceivers::class, 'team_id');
+        return $this->hasOne(TeamReceivers::class, 'team_round_id');
     }
 
     public function activityLogs() : HasMany
     {
-        return $this->hasMany(TeamActivityLog::class, 'team_id')->orderBy('created_at', 'desc');
+        return $this->hasMany(TeamActivityLog::class, 'team_round_id')->orderBy('created_at', 'desc');
     }
 
     public function squads() : HasMany

--- a/app/Policies/TeamReceiversPolicy.php
+++ b/app/Policies/TeamReceiversPolicy.php
@@ -17,7 +17,7 @@ class TeamReceiversPolicy
 
     public function view(User $user, TeamReceivers $teamReceivers): bool
     {
-        return $user->clubhouse_id === $teamReceivers->teams->clubhouse_id;
+        return $user->clubhouse_id === $teamReceivers->team->clubhouse_id;
     }
 
     public function create(User $user): bool

--- a/database/migrations/2026_04_25_150000_rename_team_fk_columns_to_team_round_id.php
+++ b/database/migrations/2026_04_25_150000_rename_team_fk_columns_to_team_round_id.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('team_receivers', function (Blueprint $table) {
+            $table->dropForeign(['team_id']);
+            $table->dropUnique(['team_id']);
+            $table->renameColumn('team_id', 'team_round_id');
+        });
+
+        Schema::table('team_receivers', function (Blueprint $table) {
+            $table->foreign('team_round_id')->references('id')->on('team_rounds')->onDelete('cascade');
+            $table->unique('team_round_id');
+        });
+
+        Schema::table('team_activity_logs', function (Blueprint $table) {
+            $table->dropForeign(['team_id']);
+            $table->dropIndex(['team_id']);
+            $table->renameColumn('team_id', 'team_round_id');
+        });
+
+        Schema::table('team_activity_logs', function (Blueprint $table) {
+            $table->foreign('team_round_id')->references('id')->on('team_rounds')->onDelete('cascade');
+            $table->index('team_round_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('team_receivers', function (Blueprint $table) {
+            $table->dropForeign(['team_round_id']);
+            $table->dropUnique(['team_round_id']);
+            $table->renameColumn('team_round_id', 'team_id');
+        });
+
+        Schema::table('team_receivers', function (Blueprint $table) {
+            $table->foreign('team_id')->references('id')->on('team_rounds')->onDelete('cascade');
+            $table->unique('team_id');
+        });
+
+        Schema::table('team_activity_logs', function (Blueprint $table) {
+            $table->dropForeign(['team_round_id']);
+            $table->dropIndex(['team_round_id']);
+            $table->renameColumn('team_round_id', 'team_id');
+        });
+
+        Schema::table('team_activity_logs', function (Blueprint $table) {
+            $table->foreign('team_id')->references('id')->on('team_rounds')->onDelete('cascade');
+            $table->index('team_id');
+        });
+    }
+};

--- a/graphql/teams.graphql
+++ b/graphql/teams.graphql
@@ -8,8 +8,8 @@ extend type Query {
     export(teamId: ID!) : String! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Queries\\Exporter")
     squadMember(id: ID! @eq) : SquadMember @find @guard @canResolved(ability: "view")
     "Team notification activity"
-    teamNotificationActivity(id: ID! @eq(key: "team_id")) : [TeamActivityLog!]! @all @orderBy(column: "created_at", direction: DESC) @guard @canResolved(ability: "view")
-    teamReceiver(team_id: ID! @eq(key: "team_id")) : TeamReceivers @find @guard @canResolved(ability: "view")
+    teamNotificationActivity(id: ID! @eq(key: "team_round_id")) : [TeamActivityLog!]! @all @orderBy(column: "created_at", direction: DESC) @guard @canResolved(ability: "view")
+    teamReceiver(team_id: ID! @eq(key: "team_round_id")) : TeamReceivers @find @guard @canResolved(ability: "view")
 }
 
 extend type Mutation {
@@ -289,7 +289,7 @@ type TeamActivityLog {
     "ID"
     id: ID!
     "Team ID"
-    teamId: ID! @rename(attribute: "team_id")
+    teamId: ID! @rename(attribute: "team_round_id")
     "Action"
     action: ActivityAction!
     "Recipient type"

--- a/local-vendor/team-fight/src/GraphQL/Mutations/SendTeamNotification.php
+++ b/local-vendor/team-fight/src/GraphQL/Mutations/SendTeamNotification.php
@@ -44,10 +44,10 @@ class SendTeamNotification
         if($receivers['saveEmails'] ?? false){
             TeamReceivers::upsert(
                 [
-                    'team_id' => $team->id,
+                    'team_round_id' => $team->id,
                     'emails' => json_encode($receivers['emails'], JSON_THROW_ON_ERROR)
                 ],
-                ['team_id']
+                ['team_round_id']
             );
         }
 

--- a/local-vendor/team-fight/src/Notifier.php
+++ b/local-vendor/team-fight/src/Notifier.php
@@ -19,7 +19,7 @@ class Notifier
         Mail::bcc($emails)->queue($this->getMailable($team, $message, $notificationType));
 
         TeamActivityLog::create([
-            'team_id' => $team->id,
+            'team_round_id' => $team->id,
             'action' => ActivityAction::from($notificationType->value),
             'recipient_type' => RecipientType::MANUAL_EMAILS,
             'recipient_count' => count($emails),

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -15,6 +15,7 @@ use App\Models\TeamReceivers;
 use App\Models\TeamRound;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Nuwave\Lighthouse\Testing\MakesGraphQLRequests;
 use Tests\TestCase;
@@ -165,7 +166,7 @@ class TeamsTest extends TestCase
         ]);
 
         TeamActivityLog::factory()->create([
-            'team_id' => $teamRound->id,
+            'team_round_id' => $teamRound->id,
             'user_id' => $user->id,
             'recipient_type' => RecipientType::TEST_SELF,
             'recipient_count' => 1,
@@ -180,6 +181,7 @@ class TeamsTest extends TestCase
                 teamNotificationActivity(id: $id) {
                     id
                     message
+                    teamId
                 }
             }
         ', [
@@ -189,7 +191,8 @@ class TeamsTest extends TestCase
             'data' => [
                 'teamNotificationActivity' => [
                     [
-                        'message' => 'Notification sent'
+                        'message' => 'Notification sent',
+                        'teamId' => $teamRound->id,
                     ]
                 ]
             ]
@@ -212,7 +215,7 @@ class TeamsTest extends TestCase
         ]);
 
         TeamReceivers::create([
-            'team_id' => $teamRound->id,
+            'team_round_id' => $teamRound->id,
             'emails' => ['test@example.com']
         ]);
 
@@ -222,6 +225,9 @@ class TeamsTest extends TestCase
             query($team_id: ID!) {
                 teamReceiver(team_id: $team_id) {
                     emails
+                    team {
+                        id
+                    }
                 }
             }
         ', [
@@ -229,7 +235,10 @@ class TeamsTest extends TestCase
         ])->assertJson([
             'data' => [
                 'teamReceiver' => [
-                    'emails' => ['test@example.com']
+                    'emails' => ['test@example.com'],
+                    'team' => [
+                        'id' => $teamRound->id,
+                    ],
                 ]
             ]
         ]);
@@ -934,6 +943,65 @@ class TeamsTest extends TestCase
                     'id' => $teamRound->id
                 ]
             ]
+        ]);
+
+        $this->assertDatabaseHas('team_activity_logs', [
+            'team_round_id' => $teamRound->id,
+            'recipient_type' => RecipientType::TEST_SELF->value,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_send_team_notification_and_store_receivers()
+    {
+        Mail::fake();
+
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::EDIT_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($input: SendTeamNotificationInput!) {
+                sendTeamNotification(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $teamRound->id,
+                'type' => 'TEAM_PUBLISH',
+                'message' => 'Hello team',
+                'receivers' => [
+                    'method' => 'MANUAL_EMAILS',
+                    'saveEmails' => true,
+                    'emails' => ['one@example.com', 'two@example.com'],
+                ]
+            ]
+        ])->assertJson([
+            'data' => [
+                'sendTeamNotification' => [
+                    'id' => $teamRound->id
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseHas('team_receivers', [
+            'team_round_id' => $teamRound->id,
+        ]);
+
+        $this->assertDatabaseHas('team_activity_logs', [
+            'team_round_id' => $teamRound->id,
+            'recipient_type' => RecipientType::MANUAL_EMAILS->value,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add migration to rename `team_receivers.team_id` and `team_activity_logs.team_id` to `team_round_id`
- update model relations and writable attributes to use `team_round_id`
- update notification write paths (`SendTeamNotification`, `Notifier`) to persist using `team_round_id`
- update GraphQL mapping for related queries and fields:
  - `teamNotificationActivity` now filters by `team_round_id`
  - `teamReceiver` now filters by `team_round_id` (keeps GraphQL argument name `team_id`)
  - `TeamActivityLog.teamId` now maps to `team_round_id`
- add/adjust GraphQL tests for related query/mutation behavior and DB persistence

## Testing
- `docker compose run --rm artisan lighthouse:clear-cache && docker compose run --rm artisan test tests/GraphQL/TeamsTest.php`
- `docker compose run --rm artisan lighthouse:clear-cache && docker compose run --rm artisan test tests/GraphQL/ValidateBasicSquadTest.php`
- `docker compose run --rm artisan lighthouse:clear-cache && docker compose run --rm artisan test tests/GraphQL/ValidateSquadTest.php`
