### PR TITLE
Add teamRound GraphQL aliases with deprecated team names

### DIFF
--- a/graphql/teams.graphql
+++ b/graphql/teams.graphql
@@ -1,15 +1,23 @@
 extend type Query {
     teamRound(id: ID! @eq) : TeamRound @find
-    teams(
+    teamRounds(
         clubhouseId: ID! @eq(key: "clubhouse_id"),
         order: _ @orderBy(columns: ["created_at", "updated_at", "game_date"]),
         gameDate: DateRange @whereBetween(key: "game_date")
     ) : [TeamRound!]! @paginate(defaultCount: 20) @guard @canResolved(ability: "view")
+    teams(
+        clubhouseId: ID! @eq(key: "clubhouse_id"),
+        order: _ @orderBy(columns: ["created_at", "updated_at", "game_date"]),
+        gameDate: DateRange @whereBetween(key: "game_date")
+    ) : [TeamRound!]! @paginate(defaultCount: 20) @guard @canResolved(ability: "view") @deprecated(reason: "Use teamRounds")
     export(teamId: ID!) : String! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Queries\\Exporter")
     squadMember(id: ID! @eq) : SquadMember @find @guard @canResolved(ability: "view")
     "Team notification activity"
     teamNotificationActivity(id: ID! @eq(key: "team_round_id")) : [TeamActivityLog!]! @all @orderBy(column: "created_at", direction: DESC) @guard @canResolved(ability: "view")
-    teamReceiver(team_id: ID! @eq(key: "team_round_id")) : TeamReceivers @find @guard @canResolved(ability: "view")
+    teamReceiver(
+        teamRoundId: ID @eq(key: "team_round_id")
+        team_id: ID @eq(key: "team_round_id") @deprecated(reason: "Use teamRoundId")
+    ) : TeamReceivers @find @guard @canResolved(ability: "view")
 }
 
 extend type Mutation {
@@ -22,10 +30,18 @@ extend type Mutation {
     updateSquad(input: UpdateSquadInput! @spread) : Squad! @update @guard @canFind(ability: "update", find: "id")
     moveSquadOrderUp(id: ID!) : Squad! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\SquadOrdering@moveSquadOrderUp") @canFind(ability: "update", find: "id")
     moveSquadOrderDown(id: ID!) : Squad! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\SquadOrdering@moveSquadOrderDown") @canFind(ability: "update", find: "id")
+    updateTeamRound(input: UpdateTeamInput! @spread): TeamRound! @guard @update @canFind(ability: "update", find: "id")
     updateTeam(input: UpdateTeamInput! @spread): TeamRound! @guard @update @canFind(ability: "update", find: "id")
+        @deprecated(reason: "Use updateTeamRound")
+    createTeamRound(input: CreateTeamInput! @spread) : TeamRound! @create @guard @canModel(ability: "create") @inject(context: "user.id", name: "user_id") @inject(context: "user.clubhouse_id", name: "clubhouse_id")
     createTeam(input: CreateTeamInput! @spread) : TeamRound! @create @guard @canModel(ability: "create") @inject(context: "user.id", name: "user_id") @inject(context: "user.clubhouse_id", name: "clubhouse_id")
+        @deprecated(reason: "Use createTeamRound")
+    copyTeamRound(id: ID!) : TeamRound! @guard @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\CopyTeam@copyTeam")
     copyTeam(id: ID!) : TeamRound! @guard @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\CopyTeam@copyTeam")
+        @deprecated(reason: "Use copyTeamRound")
+    deleteTeamRound(id: ID! @eq) : TeamRound! @guard @delete @canFind(ability: "delete", find: "id")
     deleteTeam(id: ID! @eq) : TeamRound! @guard @delete @canFind(ability: "delete", find: "id")
+        @deprecated(reason: "Use deleteTeamRound")
     "Sending notifications to all players"
     sendTeamNotification(input: SendTeamNotificationInput! @spread) : TeamRound! @guard @canFind(ability: "update", find: "id") @inject(context: "user.id", name: "user_id") @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\SendTeamNotification")
     "Changes all player points to the new version. Does not update if squad has a specific version"

--- a/resources/js/admin-v2/views/team-fight/ListTeamFights.vue
+++ b/resources/js/admin-v2/views/team-fight/ListTeamFights.vue
@@ -118,7 +118,7 @@ export default {
                             {
                                 mutation: gql`
                                     mutation ($id: ID!){
-                                        deleteTeam(id: $id){
+                                        deleteTeamRound(id: $id){
                                             id
                                         }
                                     }
@@ -147,7 +147,7 @@ export default {
                             {
                                 mutation: gql`
                                     mutation ($id: ID!){
-                                        copyTeam(id: $id){
+                                        copyTeamRound(id: $id){
                                             id
                                             name
                                         }
@@ -161,7 +161,7 @@ export default {
                                 {
                                     duration: 5000,
                                     type: 'is-success',
-                                    message: "Holdrunden kopiret. Den hedder \"" + data?.copyTeam?.name + "\""
+                                    message: "Holdrunden kopiret. Den hedder \"" + data?.copyTeamRound?.name + "\""
                                 })
                             this.$apollo.queries.teams.refetch()
                         })
@@ -199,8 +199,8 @@ export default {
     apollo: {
         teams: {
             query: gql`
-                query Teams($clubhouseId: ID!, $first: Int!, $page: Int, $order: [QueryTeamsOrderOrderByClause!], $gameDate: DateRange){
-                    teams(clubhouseId: $clubhouseId, order: $order, first: $first, page: $page, gameDate: $gameDate){
+                query TeamRounds($clubhouseId: ID!, $first: Int!, $page: Int, $order: [QueryTeamRoundsOrderOrderByClause!], $gameDate: DateRange){
+                    teamRounds(clubhouseId: $clubhouseId, order: $order, first: $first, page: $page, gameDate: $gameDate){
                         data{
                             id,
                             name,
@@ -215,6 +215,9 @@ export default {
                     }
                 },
             `,
+            update(data) {
+                return data.teamRounds;
+            },
             variables () {
                 // Use vue reactive properties here
                 return {

--- a/resources/js/admin-v2/views/team-fight/TeamFightNotify.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamFightNotify.vue
@@ -102,8 +102,8 @@ export default {
     apollo: {
         receiver: {
             query: gql`
-                query receiver($team_id: ID!){
-                    receiver : teamReceiver(team_id: $team_id){
+                query receiver($teamRoundId: ID!){
+                    receiver : teamReceiver(teamRoundId: $teamRoundId){
                         id
                         emails
                     }
@@ -111,7 +111,7 @@ export default {
             `,
             variables(){
                 return {
-                    team_id: this.teamFightId
+                    teamRoundId: this.teamFightId
                 }
             },
             result({data}){

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -112,6 +112,51 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
+    public function it_can_query_team_rounds_with_pagination()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        TeamRound::factory()->count(3)->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            query($clubhouseId: ID!) {
+                teamRounds(clubhouseId: $clubhouseId, first: 10) {
+                    data {
+                        id
+                        name
+                    }
+                    paginatorInfo {
+                        total
+                        count
+                    }
+                }
+            }
+        ', [
+            'clubhouseId' => $clubhouse->id
+        ])->assertJsonCount(3, 'data.teamRounds.data')
+          ->assertJson([
+            'data' => [
+                'teamRounds' => [
+                    'paginatorInfo' => [
+                        'total' => 3,
+                        'count' => 3
+                    ]
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_export_a_team()
     {
         Storage::fake('public');
@@ -247,6 +292,51 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
+    public function it_can_query_team_receiver_by_team_round_id()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+
+        TeamReceivers::create([
+            'team_round_id' => $teamRound->id,
+            'emails' => ['test@example.com']
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            query($teamRoundId: ID!) {
+                teamReceiver(teamRoundId: $teamRoundId) {
+                    emails
+                    team {
+                        id
+                    }
+                }
+            }
+        ', [
+            'teamRoundId' => $teamRound->id
+        ])->assertJson([
+            'data' => [
+                'teamReceiver' => [
+                    'emails' => ['test@example.com'],
+                    'team' => [
+                        'id' => $teamRound->id,
+                    ],
+                ]
+            ]
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_create_a_team()
     {
         $clubhouse = Clubhouse::factory()->create();
@@ -279,6 +369,46 @@ class TeamsTest extends TestCase
 
         $this->assertDatabaseHas('team_rounds', [
             'name' => 'New Team',
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_team_round()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::CREATE_TEAMROUNDS->value);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($input: CreateTeamInput!) {
+                createTeamRound(input: $input) {
+                    id
+                    name
+                }
+            }
+        ', [
+            'input' => [
+                'name' => 'New Team Round',
+                'gameDate' => '2023-01-01',
+                'version' => '2023-01-01'
+            ]
+        ])->assertJson([
+            'data' => [
+                'createTeamRound' => [
+                    'name' => 'New Team Round'
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseHas('team_rounds', [
+            'name' => 'New Team Round',
             'clubhouse_id' => $clubhouse->id,
             'user_id' => $user->id
         ]);
@@ -334,6 +464,53 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
+    public function it_can_update_a_team_round()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::EDIT_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id,
+            'name' => 'Old Name'
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($input: UpdateTeamInput!) {
+                updateTeamRound(input: $input) {
+                    id
+                    name
+                }
+            }
+        ', [
+            'input' => [
+                'id' => $teamRound->id,
+                'name' => 'Updated Team Round Name',
+                'gameDate' => '2023-02-01',
+                'version' => '2023-02-01'
+            ]
+        ])->assertJson([
+            'data' => [
+                'updateTeamRound' => [
+                    'id' => $teamRound->id,
+                    'name' => 'Updated Team Round Name'
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseHas('team_rounds', [
+            'id' => $teamRound->id,
+            'name' => 'Updated Team Round Name'
+        ]);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_delete_a_team()
     {
         $clubhouse = Clubhouse::factory()->create();
@@ -359,6 +536,44 @@ class TeamsTest extends TestCase
         ])->assertJson([
             'data' => [
                 'deleteTeam' => [
+                    'id' => $teamRound->id
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseMissing('team_rounds', [
+            'id' => $teamRound->id
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_delete_a_team_round()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::DELETE_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($id: ID!) {
+                deleteTeamRound(id: $id) {
+                    id
+                }
+            }
+        ', [
+            'id' => $teamRound->id
+        ])->assertJson([
+            'data' => [
+                'deleteTeamRound' => [
                     'id' => $teamRound->id
                 ]
             ]
@@ -399,6 +614,47 @@ class TeamsTest extends TestCase
         ])->assertJson([
             'data' => [
                 'copyTeam' => [
+                    'name' => 'Kopi af Original Team'
+                ]
+            ]
+        ]);
+
+        $this->assertDatabaseHas('team_rounds', [
+            'name' => 'Kopi af Original Team',
+            'clubhouse_id' => $clubhouse->id
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_copy_a_team_round()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id,
+            'name' => 'Original Team'
+        ]);
+
+        $this->actingAs($user, 'api');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($id: ID!) {
+                copyTeamRound(id: $id) {
+                    id
+                    name
+                }
+            }
+        ', [
+            'id' => $teamRound->id
+        ])->assertJson([
+            'data' => [
+                'copyTeamRound' => [
                     'name' => 'Kopi af Original Team'
                 ]
             ]


### PR DESCRIPTION
## Summary
- add new GraphQL aliases aligned to the TeamRound naming
  - query: `teamRounds`
  - mutations: `createTeamRound`, `updateTeamRound`, `copyTeamRound`, `deleteTeamRound`
- keep old GraphQL names as backward-compatible aliases and mark them deprecated
  - `teams`, `createTeam`, `updateTeam`, `copyTeam`, `deleteTeam`
- extend `teamReceiver` to accept `teamRoundId` while keeping `team_id` as deprecated arg
- update one frontend flow to consume new names (team-fight listing + notify receiver query)
- add GraphQL tests for new aliases while existing tests keep coverage for old names

## Testing
- `docker compose run --rm artisan lighthouse:clear-cache && docker compose run --rm artisan test tests/GraphQL/TeamsTest.php`
- `docker compose run --rm artisan lighthouse:clear-cache && docker compose run --rm artisan test tests/GraphQL/ValidateBasicSquadTest.php`
- `docker compose run --rm artisan lighthouse:clear-cache && docker compose run --rm artisan test tests/GraphQL/ValidateSquadTest.php`
