### PR TITLE
Refactor team-fight frontend to canonical teamRound mutations

### DIFF
--- a/resources/js/admin-v2/views/team-fight/TeamFight.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamFight.vue
@@ -9,7 +9,7 @@
             <b-tooltip type="is-info" label="Auto-save er slået til. Auto-save sker KUN når der sker ændringer på holdet"
                        position="is-bottom">
                 <b-button :loading="saving" :class="{'is-success': this.savingIcon === 'check'}" :icon-left="savingIcon"
-                          @click="saveTeams">Gem
+                          @click="saveTeamRound">Gem
                 </b-button>
             </b-tooltip>
             <b-dropdown aria-role="list" class="ml-2">
@@ -775,7 +775,7 @@ export default {
                     this.saving = false
                 })
         },
-        saveTeams() {
+        saveTeamRound() {
             if (this.saving === true) {
                 return
             }
@@ -783,8 +783,8 @@ export default {
             this.$apollo.mutate(
                 {
                     mutation: gql`
-                        mutation updateTeam($input: UpdateTeamInput!){
-                          updateTeam(input: $input){
+                        mutation updateTeamRound($input: UpdateTeamInput!){
+                          updateTeamRound(input: $input){
                             id
                             name
                             gameDate
@@ -827,4 +827,3 @@ export default {
     }
 }
 </script>
-

--- a/resources/js/admin-v2/views/team-fight/TeamFightCreate.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamFightCreate.vue
@@ -5,7 +5,7 @@
             Opret holdrunde
         </hero-bar>
         <section class="section is-main-section">
-            <form @submit.prevent="createTeam" v-if="!$apollo.queries.me.loading" class="column">
+            <form @submit.prevent="createTeamRound" v-if="!$apollo.queries.me.loading" class="column">
                 <b-field label="Navn">
                     <b-input dusk="team-fight-name-input" v-model="name" required placeholder="fx. Runde 1"></b-input>
                 </b-field>
@@ -59,7 +59,7 @@ export default {
         }
     },
     methods: {
-        createTeam() {
+        createTeamRound() {
             if(this.gameDate === null){
                 this.$buefy.snackbar.open({
                     duration: 4000,
@@ -71,9 +71,9 @@ export default {
             }
 
             this.loading = true
-            const createTeamGQL = gql`
+            const createTeamRoundGQL = gql`
                         mutation ($input: CreateTeamInput!){
-                          createTeam(input: $input){
+                          createTeamRound(input: $input){
                             id
                             name
                             gameDate
@@ -83,7 +83,7 @@ export default {
             this.$apollo
                 .mutate(
                     {
-                        mutation: createTeamGQL,
+                        mutation: createTeamRoundGQL,
                         variables: {
                             input: {
                                 name: this.name,
@@ -99,7 +99,7 @@ export default {
                             type: 'is-success',
                             message: `Dit hold er gemt`
                         })
-                    this.$router.push({name: 'team-fight-edit', params: {teamUUID: data.createTeam.id}})
+                    this.$router.push({name: 'team-fight-edit', params: {teamUUID: data.createTeamRound.id}})
                 }).finally(() => {
                 this.loading = false
             })


### PR DESCRIPTION
Summary:
- switch team-fight create flow from deprecated createTeam to createTeamRound
- switch team-fight update/save flow from deprecated updateTeam to updateTeamRound
- align local method names with canonical operation names

Verification:
- docker compose run --rm artisan test tests/GraphQL/TeamsTest.php
- yarn run build
- docker compose run --rm artisan dusk tests/Browser/TeamFightCreateTest.php

Notes:
- dashboard actions browser test is intentionally excluded from this PR and will be handled manually