### PR TITLE
Remove deprecated GraphQL team aliases

### DIFF
--- a/graphql/teams.graphql
+++ b/graphql/teams.graphql
@@ -5,18 +5,12 @@ extend type Query {
         order: _ @orderBy(columns: ["created_at", "updated_at", "game_date"]),
         gameDate: DateRange @whereBetween(key: "game_date")
     ) : [TeamRound!]! @paginate(defaultCount: 20) @guard @canResolved(ability: "view")
-    teams(
-        clubhouseId: ID! @eq(key: "clubhouse_id"),
-        order: _ @orderBy(columns: ["created_at", "updated_at", "game_date"]),
-        gameDate: DateRange @whereBetween(key: "game_date")
-    ) : [TeamRound!]! @paginate(defaultCount: 20) @guard @canResolved(ability: "view") @deprecated(reason: "Use teamRounds")
     export(teamId: ID!) : String! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Queries\\Exporter")
     squadMember(id: ID! @eq) : SquadMember @find @guard @canResolved(ability: "view")
     "Team notification activity"
     teamNotificationActivity(id: ID! @eq(key: "team_round_id")) : [TeamActivityLog!]! @all @orderBy(column: "created_at", direction: DESC) @guard @canResolved(ability: "view")
     teamReceiver(
         teamRoundId: ID @eq(key: "team_round_id")
-        team_id: ID @eq(key: "team_round_id") @deprecated(reason: "Use teamRoundId")
     ) : TeamReceivers @find @guard @canResolved(ability: "view")
 }
 
@@ -31,17 +25,9 @@ extend type Mutation {
     moveSquadOrderUp(id: ID!) : Squad! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\SquadOrdering@moveSquadOrderUp") @canFind(ability: "update", find: "id")
     moveSquadOrderDown(id: ID!) : Squad! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\SquadOrdering@moveSquadOrderDown") @canFind(ability: "update", find: "id")
     updateTeamRound(input: UpdateTeamInput! @spread): TeamRound! @guard @update @canFind(ability: "update", find: "id")
-    updateTeam(input: UpdateTeamInput! @spread): TeamRound! @guard @update @canFind(ability: "update", find: "id")
-        @deprecated(reason: "Use updateTeamRound")
     createTeamRound(input: CreateTeamInput! @spread) : TeamRound! @create @guard @canModel(ability: "create") @inject(context: "user.id", name: "user_id") @inject(context: "user.clubhouse_id", name: "clubhouse_id")
-    createTeam(input: CreateTeamInput! @spread) : TeamRound! @create @guard @canModel(ability: "create") @inject(context: "user.id", name: "user_id") @inject(context: "user.clubhouse_id", name: "clubhouse_id")
-        @deprecated(reason: "Use createTeamRound")
     copyTeamRound(id: ID!) : TeamRound! @guard @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\CopyTeam@copyTeam")
-    copyTeam(id: ID!) : TeamRound! @guard @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\CopyTeam@copyTeam")
-        @deprecated(reason: "Use copyTeamRound")
     deleteTeamRound(id: ID! @eq) : TeamRound! @guard @delete @canFind(ability: "delete", find: "id")
-    deleteTeam(id: ID! @eq) : TeamRound! @guard @delete @canFind(ability: "delete", find: "id")
-        @deprecated(reason: "Use deleteTeamRound")
     "Sending notifications to all players"
     sendTeamNotification(input: SendTeamNotificationInput! @spread) : TeamRound! @guard @canFind(ability: "update", find: "id") @inject(context: "user.id", name: "user_id") @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\SendTeamNotification")
     "Changes all player points to the new version. Does not update if squad has a specific version"

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -67,51 +67,6 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
-    public function it_can_query_teams_with_pagination()
-    {
-        $clubhouse = Clubhouse::factory()->create();
-        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
-        setPermissionsTeamId($clubhouse->id);
-        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
-
-        TeamRound::factory()->count(3)->create([
-            'clubhouse_id' => $clubhouse->id,
-            'user_id' => $user->id
-        ]);
-
-        $this->actingAs($user, 'api');
-
-        $this->graphQL(/** @lang GraphQL */ '
-            query($clubhouseId: ID!) {
-                teams(clubhouseId: $clubhouseId, first: 10) {
-                    data {
-                        id
-                        name
-                    }
-                    paginatorInfo {
-                        total
-                        count
-                    }
-                }
-            }
-        ', [
-            'clubhouseId' => $clubhouse->id
-        ])->assertJsonCount(3, 'data.teams.data')
-          ->assertJson([
-            'data' => [
-                'teams' => [
-                    'paginatorInfo' => [
-                        'total' => 3,
-                        'count' => 3
-                    ]
-                ]
-            ]
-        ]);
-    }
-
-    /**
-     * @test
-     */
     public function it_can_query_team_rounds_with_pagination()
     {
         $clubhouse = Clubhouse::factory()->create();
@@ -247,51 +202,6 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
-    public function it_can_query_team_receiver()
-    {
-        $clubhouse = Clubhouse::factory()->create();
-        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
-        setPermissionsTeamId($clubhouse->id);
-        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
-
-        $teamRound = TeamRound::factory()->create([
-            'clubhouse_id' => $clubhouse->id,
-            'user_id' => $user->id
-        ]);
-
-        TeamReceivers::create([
-            'team_round_id' => $teamRound->id,
-            'emails' => ['test@example.com']
-        ]);
-
-        $this->actingAs($user, 'api');
-
-        $this->graphQL(/** @lang GraphQL */ '
-            query($team_id: ID!) {
-                teamReceiver(team_id: $team_id) {
-                    emails
-                    team {
-                        id
-                    }
-                }
-            }
-        ', [
-            'team_id' => $teamRound->id
-        ])->assertJson([
-            'data' => [
-                'teamReceiver' => [
-                    'emails' => ['test@example.com'],
-                    'team' => [
-                        'id' => $teamRound->id,
-                    ],
-                ]
-            ]
-        ]);
-    }
-
-    /**
-     * @test
-     */
     public function it_can_query_team_receiver_by_team_round_id()
     {
         $clubhouse = Clubhouse::factory()->create();
@@ -337,46 +247,6 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
-    public function it_can_create_a_team()
-    {
-        $clubhouse = Clubhouse::factory()->create();
-        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
-        setPermissionsTeamId($clubhouse->id);
-        $user->givePermissionTo(Permission::CREATE_TEAMROUNDS->value);
-
-        $this->actingAs($user, 'api');
-
-        $this->graphQL(/** @lang GraphQL */ '
-            mutation($input: CreateTeamInput!) {
-                createTeam(input: $input) {
-                    id
-                    name
-                }
-            }
-        ', [
-            'input' => [
-                'name' => 'New Team',
-                'gameDate' => '2023-01-01',
-                'version' => '2023-01-01'
-            ]
-        ])->assertJson([
-            'data' => [
-                'createTeam' => [
-                    'name' => 'New Team'
-                ]
-            ]
-        ]);
-
-        $this->assertDatabaseHas('team_rounds', [
-            'name' => 'New Team',
-            'clubhouse_id' => $clubhouse->id,
-            'user_id' => $user->id
-        ]);
-    }
-
-    /**
-     * @test
-     */
     public function it_can_create_a_team_round()
     {
         $clubhouse = Clubhouse::factory()->create();
@@ -411,53 +281,6 @@ class TeamsTest extends TestCase
             'name' => 'New Team Round',
             'clubhouse_id' => $clubhouse->id,
             'user_id' => $user->id
-        ]);
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_update_a_team()
-    {
-        $clubhouse = Clubhouse::factory()->create();
-        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
-        setPermissionsTeamId($clubhouse->id);
-        $user->givePermissionTo(Permission::EDIT_TEAMROUNDS->value);
-
-        $teamRound = TeamRound::factory()->create([
-            'clubhouse_id' => $clubhouse->id,
-            'user_id' => $user->id,
-            'name' => 'Old Name'
-        ]);
-
-        $this->actingAs($user, 'api');
-
-        $this->graphQL(/** @lang GraphQL */ '
-            mutation($input: UpdateTeamInput!) {
-                updateTeam(input: $input) {
-                    id
-                    name
-                }
-            }
-        ', [
-            'input' => [
-                'id' => $teamRound->id,
-                'name' => 'Updated Name',
-                'gameDate' => '2023-02-01',
-                'version' => '2023-02-01'
-            ]
-        ])->assertJson([
-            'data' => [
-                'updateTeam' => [
-                    'id' => $teamRound->id,
-                    'name' => 'Updated Name'
-                ]
-            ]
-        ]);
-
-        $this->assertDatabaseHas('team_rounds', [
-            'id' => $teamRound->id,
-            'name' => 'Updated Name'
         ]);
     }
 
@@ -511,44 +334,6 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
-    public function it_can_delete_a_team()
-    {
-        $clubhouse = Clubhouse::factory()->create();
-        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
-        setPermissionsTeamId($clubhouse->id);
-        $user->givePermissionTo(Permission::DELETE_TEAMROUNDS->value);
-
-        $teamRound = TeamRound::factory()->create([
-            'clubhouse_id' => $clubhouse->id,
-            'user_id' => $user->id
-        ]);
-
-        $this->actingAs($user, 'api');
-
-        $this->graphQL(/** @lang GraphQL */ '
-            mutation($id: ID!) {
-                deleteTeam(id: $id) {
-                    id
-                }
-            }
-        ', [
-            'id' => $teamRound->id
-        ])->assertJson([
-            'data' => [
-                'deleteTeam' => [
-                    'id' => $teamRound->id
-                ]
-            ]
-        ]);
-
-        $this->assertDatabaseMissing('team_rounds', [
-            'id' => $teamRound->id
-        ]);
-    }
-
-    /**
-     * @test
-     */
     public function it_can_delete_a_team_round()
     {
         $clubhouse = Clubhouse::factory()->create();
@@ -581,47 +366,6 @@ class TeamsTest extends TestCase
 
         $this->assertDatabaseMissing('team_rounds', [
             'id' => $teamRound->id
-        ]);
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_copy_a_team()
-    {
-        $clubhouse = Clubhouse::factory()->create();
-        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
-        setPermissionsTeamId($clubhouse->id);
-        $user->givePermissionTo(Permission::VIEW_TEAMROUNDS->value);
-
-        $teamRound = TeamRound::factory()->create([
-            'clubhouse_id' => $clubhouse->id,
-            'user_id' => $user->id,
-            'name' => 'Original Team'
-        ]);
-
-        $this->actingAs($user, 'api');
-
-        $this->graphQL(/** @lang GraphQL */ '
-            mutation($id: ID!) {
-                copyTeam(id: $id) {
-                    id
-                    name
-                }
-            }
-        ', [
-            'id' => $teamRound->id
-        ])->assertJson([
-            'data' => [
-                'copyTeam' => [
-                    'name' => 'Kopi af Original Team'
-                ]
-            ]
-        ]);
-
-        $this->assertDatabaseHas('team_rounds', [
-            'name' => 'Kopi af Original Team',
-            'clubhouse_id' => $clubhouse->id
         ]);
     }
 


### PR DESCRIPTION
Summary:
- remove deprecated GraphQL aliases from teams schema: teams query alias, createTeam, updateTeam, copyTeam, deleteTeam, and teamReceiver(team_id)
- keep only canonical teamRound/teamRounds operations
- remove alias-only coverage from TeamsTest while preserving canonical coverage

Validation:
- docker compose run --rm artisan test tests/GraphQL/TeamsTest.php