### PR TITLE
Rename team GraphQL args/inputs to teamRound

### DIFF
--- a/graphql/teams.graphql
+++ b/graphql/teams.graphql
@@ -5,7 +5,7 @@ extend type Query {
         order: _ @orderBy(columns: ["created_at", "updated_at", "game_date"]),
         gameDate: DateRange @whereBetween(key: "game_date")
     ) : [TeamRound!]! @paginate(defaultCount: 20) @guard @canResolved(ability: "view")
-    export(teamId: ID!) : String! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Queries\\Exporter")
+    export(teamRoundId: ID!) : String! @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Queries\\Exporter")
     squadMember(id: ID! @eq) : SquadMember @find @guard @canResolved(ability: "view")
     "Team notification activity"
     teamNotificationActivity(id: ID! @eq(key: "team_round_id")) : [TeamActivityLog!]! @all @orderBy(column: "created_at", direction: DESC) @guard @canResolved(ability: "view")
@@ -31,7 +31,7 @@ extend type Mutation {
     "Sending notifications to all players"
     sendTeamNotification(input: SendTeamNotificationInput! @spread) : TeamRound! @guard @canFind(ability: "update", find: "id") @inject(context: "user.id", name: "user_id") @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\SendTeamNotification")
     "Changes all player points to the new version. Does not update if squad has a specific version"
-    updatePointsTeam(id: ID!, version: String!) : TeamRound @guard @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\UpdateTeams@updatePointsOnAllSquadsInTeam")
+    updatePointsTeamRound(id: ID!, version: String!) : TeamRound @guard @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\UpdateTeams@updatePointsOnAllSquadsInTeam")
     "Changes all player points to the new version."
     updatePointsSquad(id: ID!, version: String) : Squad @guard @field(resolver: "FlyCompany\\TeamFight\\GraphQL\\Mutations\\UpdateTeams@updatePointsOnSquad")
 }
@@ -147,7 +147,7 @@ input UpdateSquadInput {
 }
 
 input CreateSquadInput {
-    team: SquadBelongsTo!
+    teamRound: SquadBelongsTo! @rename(attribute: "team")
     playerLimit: Int!
     league: LeagueType!
     categories: CreateCategoryHasManyInput!

--- a/local-vendor/team-fight/src/GraphQL/Queries/Exporter.php
+++ b/local-vendor/team-fight/src/GraphQL/Queries/Exporter.php
@@ -32,12 +32,12 @@ class Exporter
     public function __invoke($root, array $args, GraphQLContext $context, ResolveInfo $resolveInfo) : string
     {
         /** @var TeamRound $team */
-        $teamId = $args['teamId'];
-        $team = TeamRound::query()->where('id', $teamId)->where('clubhouse_id', $context->user()->clubhouse_id)->firstOrFail();
+        $teamRoundId = $args['teamRoundId'];
+        $team = TeamRound::query()->where('id', $teamRoundId)->where('clubhouse_id', $context->user()->clubhouse_id)->firstOrFail();
         $csvData = $this->exporter->exportToCSV($team);
 
         $randomNumber = date('d-m-Y_H-i-s');
-        $filePath = "team-fight/exports/$teamId-$randomNumber.csv";
+        $filePath = "team-fight/exports/$teamRoundId-$randomNumber.csv";
         $success = Storage::disk('public')->put($filePath, (chr(0xEF).chr(0xBB).chr(0xBF)).$csvData);
         if($success === false){
             throw new \RuntimeException('Failed to save '.$filePath);

--- a/resources/js/admin-v2/views/team-fight/AddTeamsButtons.vue
+++ b/resources/js/admin-v2/views/team-fight/AddTeamsButtons.vue
@@ -89,7 +89,7 @@ export default {
                     variables: {
                         input: {
                             ...{
-                                team: {
+                                teamRound: {
                                     connect: this.teamId
                                 }
                             },

--- a/resources/js/admin-v2/views/team-fight/TeamFight.vue
+++ b/resources/js/admin-v2/views/team-fight/TeamFight.vue
@@ -313,12 +313,12 @@ export default {
         exportToCSV() {
             this.$apollo.query({
                                    query: gql`
-                                        query exportToCSV($teamId: ID!){
-                                            export(teamId:$teamId)
+                                        query exportToCSV($teamRoundId: ID!){
+                                            export(teamRoundId:$teamRoundId)
                                         }
                                     `,
                                    variables: {
-                                       teamId: this.teamFightId
+                                       teamRoundId: this.teamFightId
                                    },
                                    fetchPolicy: "network-only"
                                }).then(({data}) => {
@@ -462,8 +462,8 @@ export default {
                        .mutate(
                            {
                                mutation: gql`
-                                    mutation updatePointsTeam($id: ID!, $version: String!){
-                                      updatePointsTeam(id: $id, version: $version){
+                                    mutation updatePointsTeamRound($id: ID!, $version: String!){
+                                      updatePointsTeamRound(id: $id, version: $version){
                                         id
                                       }
                                     }

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -129,11 +129,11 @@ class TeamsTest extends TestCase
         $this->actingAs($user, 'api');
 
         $response = $this->graphQL(/** @lang GraphQL */ '
-            query($teamId: ID!) {
-                export(teamId: $teamId)
+            query($teamRoundId: ID!) {
+                export(teamRoundId: $teamRoundId)
             }
         ', [
-            'teamId' => $teamRound->id,
+            'teamRoundId' => $teamRound->id,
         ]);
 
         $response->assertJsonStructure([
@@ -437,7 +437,7 @@ class TeamsTest extends TestCase
             }
         ', [
             'input' => [
-                'team' => ['connect' => $teamRound->id],
+                'teamRound' => ['connect' => $teamRound->id],
                 'playerLimit' => 10,
                 'league' => 'LIGA',
                 'categories' => [
@@ -1008,7 +1008,7 @@ class TeamsTest extends TestCase
     /**
      * @test
      */
-    public function it_can_update_points_team()
+    public function it_can_update_points_team_round()
     {
         $clubhouse = Clubhouse::factory()->create();
         $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
@@ -1024,7 +1024,7 @@ class TeamsTest extends TestCase
 
         $this->graphQL(/** @lang GraphQL */ '
             mutation($id: ID!, $version: String!) {
-                updatePointsTeam(id: $id, version: $version) {
+                updatePointsTeamRound(id: $id, version: $version) {
                     id
                     version
                 }
@@ -1034,7 +1034,7 @@ class TeamsTest extends TestCase
             'version' => '2023-01-01'
         ])->assertJson([
             'data' => [
-                'updatePointsTeam' => [
+                'updatePointsTeamRound' => [
                     'id' => $teamRound->id,
                     'version' => '2023-01-01'
                 ]


### PR DESCRIPTION
Summary:
- rename export query argument from teamId to teamRoundId
- rename createSquad input key from team to teamRound and keep backend relation mapping through rename
- rename updatePointsTeam mutation to updatePointsTeamRound
- update frontend team-fight callers and Teams GraphQL tests
- update Exporter resolver to read teamRoundId

Validation:
- docker compose run --rm artisan lighthouse:clear-cache
- docker compose run --rm artisan test tests/GraphQL/TeamsTest.php
- yarn run build