### PR TITLE
refactor(graphql): add canonical teamRoundId fields and args

### DIFF
--- a/graphql/cancellation.graphql
+++ b/graphql/cancellation.graphql
@@ -19,6 +19,7 @@ extend type Mutation {
 
 input CancellationInput {
     refId: String!
+    teamRoundId: String @rename(attribute: "teamId")
     teamId: String
     message: String
     email: String @rules(apply: ["email"])
@@ -80,6 +81,7 @@ type CancellationCollector {
 type Cancellation {
     id: ID
     refId: String!
+    teamRoundId: String @rename(attribute: "teamId")
     teamId: String
     message: String
     member: Member!

--- a/graphql/club.graphql
+++ b/graphql/club.graphql
@@ -19,6 +19,7 @@ extend type Query{
         "Clubhouse"
         clubhouse: Int! @scope
         version: Date!
+        teamRoundId: String
         teamId: String
         name: String @where(operator: "like")
         rankingList: RankingList! = WOMEN_LEVEL

--- a/graphql/teams.graphql
+++ b/graphql/teams.graphql
@@ -12,6 +12,9 @@ extend type Query {
     teamReceiver(
         teamRoundId: ID @eq(key: "team_round_id")
     ) : TeamReceivers @find @guard @canResolved(ability: "view")
+    teamRoundReceiver(
+        teamRoundId: ID @eq(key: "team_round_id")
+    ) : TeamReceivers @find @guard @canResolved(ability: "view")
 }
 
 extend type Mutation {
@@ -38,6 +41,7 @@ extend type Mutation {
 
 type TeamReceivers {
     id: ID!
+    teamRound: TeamRound @belongsTo(relation: "team")
     team: TeamRound @belongsTo
     emails: [String!]!
 }
@@ -290,6 +294,8 @@ type TeamRound {
 type TeamActivityLog {
     "ID"
     id: ID!
+    "Team Round ID"
+    teamRoundId: ID! @rename(attribute: "team_round_id")
     "Team ID"
     teamId: ID! @rename(attribute: "team_round_id")
     "Action"
@@ -311,6 +317,7 @@ type TeamActivityLog {
     "Updated at"
     updatedAt: DateTime @rename(attribute: "updated_at")
     "Team"
+    teamRound: TeamRound! @belongsTo(relation: "team")
     team: TeamRound! @belongsTo
     "User"
     user: User @belongsTo

--- a/local-vendor/members/src/MemberSearch.php
+++ b/local-vendor/members/src/MemberSearch.php
@@ -41,7 +41,7 @@ class MemberSearch
                     $this->applyRanking($query, $rankingList);
                 });
         }
-        $teamId = $args['teamId'] ?? null;
+        $teamId = $args['teamRoundId'] ?? ($args['teamId'] ?? null);
         if($teamId !== null){
             $builder->notOnSquad($teamId);
         }

--- a/tests/GraphQL/TeamsTest.php
+++ b/tests/GraphQL/TeamsTest.php
@@ -4,6 +4,7 @@ namespace Tests\GraphQL;
 
 use App\Enums\Permission;
 use App\Enums\RecipientType;
+use App\Models\Club;
 use App\Models\Clubhouse;
 use App\Models\Member;
 use App\Models\Point;
@@ -181,7 +182,14 @@ class TeamsTest extends TestCase
                 teamNotificationActivity(id: $id) {
                     id
                     message
+                    teamRoundId
                     teamId
+                    teamRound {
+                        id
+                    }
+                    team {
+                        id
+                    }
                 }
             }
         ', [
@@ -192,7 +200,14 @@ class TeamsTest extends TestCase
                 'teamNotificationActivity' => [
                     [
                         'message' => 'Notification sent',
+                        'teamRoundId' => $teamRound->id,
                         'teamId' => $teamRound->id,
+                        'teamRound' => [
+                            'id' => $teamRound->id,
+                        ],
+                        'team' => [
+                            'id' => $teamRound->id,
+                        ],
                     ]
                 ]
             ]
@@ -225,6 +240,18 @@ class TeamsTest extends TestCase
             query($teamRoundId: ID!) {
                 teamReceiver(teamRoundId: $teamRoundId) {
                     emails
+                    teamRound {
+                        id
+                    }
+                    team {
+                        id
+                    }
+                }
+                teamRoundReceiver(teamRoundId: $teamRoundId) {
+                    emails
+                    teamRound {
+                        id
+                    }
                     team {
                         id
                     }
@@ -236,11 +263,167 @@ class TeamsTest extends TestCase
             'data' => [
                 'teamReceiver' => [
                     'emails' => ['test@example.com'],
+                    'teamRound' => [
+                        'id' => $teamRound->id,
+                    ],
                     'team' => [
                         'id' => $teamRound->id,
                     ],
-                ]
+                ],
+                'teamRoundReceiver' => [
+                    'emails' => ['test@example.com'],
+                    'teamRound' => [
+                        'id' => $teamRound->id,
+                    ],
+                    'team' => [
+                        'id' => $teamRound->id,
+                    ],
+                ],
             ]
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_query_member_search_points_with_team_round_id_filter()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+        setPermissionsTeamId($clubhouse->id);
+        $this->actingAs($user, 'api');
+
+        $club = Club::query()->create([
+            'name1' => 'Test Club',
+            'badmintonPlayerId' => 12345,
+        ]);
+        $clubhouse->clubs()->attach($club->id);
+
+        $member = Member::query()->create([
+            'refId' => '9001011234',
+            'name' => 'Member Search Player',
+            'gender' => 'M',
+            'birthday' => '1990-01-01',
+            'playable' => true,
+            'inactive' => false,
+        ]);
+        $member->clubs()->attach($club->id);
+
+        Point::query()->create([
+            'member_id' => $member->id,
+            'points' => 100,
+            'position' => 1,
+            'category' => 'HS',
+            'vintage' => 'SEN',
+            'version' => '2024-01-01',
+        ]);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id,
+        ]);
+        $squad = Squad::query()->create([
+            'team_round_id' => $teamRound->id,
+            'playerLimit' => 10,
+            'league' => 'OTHER',
+            'order' => 1,
+        ]);
+        $category = $squad->categories()->create([
+            'category' => 'HS',
+            'name' => '1. HS',
+        ]);
+        $category->players()->create([
+            'name' => $member->name,
+            'gender' => $member->gender,
+            'member_ref_id' => $member->refId,
+        ]);
+
+        $this->graphQL(/** @lang GraphQL */ '
+            query($clubhouse: Int!, $version: Date!, $rankingList: RankingList!, $teamRoundId: String!) {
+                memberSearchPoints(
+                    clubhouse: $clubhouse,
+                    version: $version,
+                    rankingList: $rankingList,
+                    teamRoundId: $teamRoundId
+                ) {
+                    data {
+                        refId
+                    }
+                }
+            }
+        ', [
+            'clubhouse' => $clubhouse->id,
+            'version' => '2024-01-01',
+            'rankingList' => 'MEN_SINGLE',
+            'teamRoundId' => $teamRound->id,
+        ])->assertJsonCount(0, 'data.memberSearchPoints.data');
+
+        $this->graphQL(/** @lang GraphQL */ '
+            query($clubhouse: Int!, $version: Date!, $rankingList: RankingList!) {
+                memberSearchPoints(
+                    clubhouse: $clubhouse,
+                    version: $version,
+                    rankingList: $rankingList
+                ) {
+                    data {
+                        refId
+                    }
+                }
+            }
+        ', [
+            'clubhouse' => $clubhouse->id,
+            'version' => '2024-01-01',
+            'rankingList' => 'MEN_SINGLE',
+        ])->assertJsonCount(1, 'data.memberSearchPoints.data')
+          ->assertJsonPath('data.memberSearchPoints.data.0.refId', $member->refId);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_cancellation_with_team_round_id()
+    {
+        $clubhouse = Clubhouse::factory()->create();
+        $user = User::factory()->create(['clubhouse_id' => $clubhouse->id]);
+
+        $teamRound = TeamRound::factory()->create([
+            'clubhouse_id' => $clubhouse->id,
+            'user_id' => $user->id,
+        ]);
+
+        $member = Member::query()->create([
+            'refId' => '9001015555',
+            'name' => 'Cancellation Player',
+            'gender' => 'M',
+            'birthday' => '1990-01-01',
+            'playable' => true,
+            'inactive' => false,
+        ]);
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation($input: CancellationInput!) {
+                createCancellation(input: $input) {
+                    id
+                    teamRoundId
+                    teamId
+                }
+            }
+        ', [
+            'input' => [
+                'refId' => $member->refId,
+                'teamRoundId' => $teamRound->id,
+                'dates' => [
+                    'create' => [
+                        ['date' => '2024-01-01'],
+                    ],
+                ],
+            ],
+        ])->assertJsonPath('data.createCancellation.teamRoundId', $teamRound->id)
+          ->assertJsonPath('data.createCancellation.teamId', $teamRound->id);
+
+        $this->assertDatabaseHas('cancellations', [
+            'refId' => $member->refId,
+            'teamId' => $teamRound->id,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Add canonical `teamRoundId` fields/args in GraphQL while keeping legacy `teamId` compatibility.
- Add `teamRoundReceiver(teamRoundId: ...)` query alias while keeping `teamReceiver(...)`.
- Add canonical relation fields (`teamRound`) on relevant GraphQL types while keeping legacy `team`.
- Update member search resolver to accept `teamRoundId` (fallback to `teamId`).
- Extend GraphQL tests to cover canonical and legacy behavior.

## Files changed
- `graphql/teams.graphql`
- `graphql/club.graphql`
- `graphql/cancellation.graphql`
- `local-vendor/members/src/MemberSearch.php`
- `tests/GraphQL/TeamsTest.php`

## Validation
- `docker compose run --rm artisan lighthouse:clear-cache`
- `docker compose run --rm artisan test tests/GraphQL/TeamsTest.php` (22 passed)
